### PR TITLE
Fix production saved bookmark reads

### DIFF
--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -4801,7 +4801,7 @@ impl BookmarkRepository for Neo4jBookmarkRepository {
                             collect(DISTINCT category.name) AS categories,
                             user.login AS user_login,
                             repo.full_name AS repo_full_name
-                     ORDER BY bookmark.created_at DESC",
+                     ORDER BY created_at DESC",
                 )
                 .param("user_id", user_id.to_string()),
             )


### PR DESCRIPTION
## Summary
- order Neo4j bookmark results by the projected `created_at` alias
- restore the live Saved page after production exposed Neo4j's post-aggregation variable restriction

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked` (54 passed, 1 ignored)
- live write already confirmed; post-deploy read will be rechecked against Aura