### PR TITLE
Fix Vercel SPA service routes

### DIFF
--- a/.github/scripts/verify-production-contract.mjs
+++ b/.github/scripts/verify-production-contract.mjs
@@ -83,6 +83,17 @@ for (const route of ['/auth/(.*)', '/graphql', '/health']) {
     `Vercel API rewrite missing for ${route}`
   );
 }
+for (const route of ['/login', '/app/(.*)']) {
+  requireContract(
+    vercel.rewrites?.some(
+      (rewrite) =>
+        rewrite.source === route &&
+        rewrite.destination?.service === 'web' &&
+        rewrite.destination.path === '/index.html'
+    ),
+    `Vercel SPA entry rewrite missing for ${route}`
+  );
+}
 for (const header of [
   'Content-Security-Policy',
   'Strict-Transport-Security',

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,9 +8,9 @@ This document describes the deployment scaffold. It does not claim that the prod
 
 `vercel.json` declares two services:
 
-- `web` builds the React/Vite single-page application and receives the catch-all route after API routes are matched.
+- `web` builds the React/Vite single-page application. Top-level `/login` and `/app/*` rewrites select its `index.html` route, while the final catch-all serves normal web assets and root requests.
 - `api` builds `Dockerfile.vercel` as a Rust container and receives `/auth/*`, `/graphql`, `/health`, `/sync/*`, `/bookmarks`, `/categories`, and `/explore*`.
-- `apps/web/vercel.json` supplies the SPA fallback so direct React Router entry points resolve to `index.html`.
+- `apps/web/vercel.json` keeps the Vite app's standalone SPA fallback; Vercel Services additionally requires the top-level web-service route selection above.
 
 The linked Vercel project's Framework Preset must be set to **Services**. Vercel only activates this topology when that project setting and the top-level `services` configuration are both present. Automatic Vercel Git deployments are disabled in `vercel.json`; the protected, main-only release workflow owns production builds and domain updates.
 

--- a/docs/ui-login-flow.md
+++ b/docs/ui-login-flow.md
@@ -97,7 +97,8 @@ The authenticated shell has three primary areas: Explore, Saved, and Settings. S
 
 - `apps/web/src/`: React routes, authentication boundary, query state, and product composition
 - `apps/web/vite.config.ts`: development API proxy and browser-test configuration
-- `apps/web/vercel.json`: production SPA fallback
+- `vercel.json`: production Services routing, including direct `/login` and `/app/*` SPA entry points
+- `apps/web/vercel.json`: standalone Vite SPA fallback
 - `packages/api_client/src/index.ts`: credentialed REST/GraphQL client and OAuth URL helper
 - `src/http.rs`: OAuth routes, cookie creation/resolution, CORS, GraphQL routing
 - `src/identity.rs` and `src/application.rs`: connection and session behavior

--- a/vercel.json
+++ b/vercel.json
@@ -61,6 +61,14 @@
       "destination": { "service": "api" }
     },
     {
+      "source": "/login",
+      "destination": { "service": "web", "path": "/index.html" }
+    },
+    {
+      "source": "/app/(.*)",
+      "destination": { "service": "web", "path": "/index.html" }
+    },
+    {
       "source": "/(.*)",
       "destination": { "service": "web" }
     }


### PR DESCRIPTION
## Fix
- route direct `/login` and `/app/*` requests to the Vite service's `/index.html` route at the top-level Vercel Services boundary
- keep the ordinary web catch-all unchanged so hashed assets, images, the favicon, and robots.txt remain static files
- make the production contract require both SPA entry rewrites and document the Services-specific behavior

## Evidence
The first React release deployed successfully, but live verification found `/login` returned 404 while `/`, `/health`, and `/auth/status` were healthy. Vercel Services treats routing into a service as final; the nested Vite rewrite was not sufficient for direct entry.

Passed locally:
- `pnpm production:check`
- `pnpm --filter @gitexplore/web build`
- `pnpm exec vercel build --prod` (both Vite and Rust services completed)
- `git diff --check`