### PR TITLE
Fix SPA request path routing

### DIFF
--- a/.github/scripts/verify-production-contract.mjs
+++ b/.github/scripts/verify-production-contract.mjs
@@ -89,9 +89,15 @@ for (const route of ['/login', '/app/(.*)']) {
       (rewrite) =>
         rewrite.source === route &&
         rewrite.destination?.service === 'web' &&
-        rewrite.destination.path === '/index.html'
+        rewrite.destination.path === undefined &&
+        rewrite.transforms?.some(
+          (transform) =>
+            transform.type === 'request.path' &&
+            transform.op === 'set' &&
+            transform.args === '/index.html'
+        )
     ),
-    `Vercel SPA entry rewrite missing for ${route}`
+    `Vercel SPA request-path transform missing for ${route}`
   );
 }
 for (const header of [

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,9 +8,9 @@ This document describes the deployment scaffold. It does not claim that the prod
 
 `vercel.json` declares two services:
 
-- `web` builds the React/Vite single-page application. Top-level `/login` and `/app/*` rewrites select its `index.html` route, while the final catch-all serves normal web assets and root requests.
+- `web` builds the React/Vite single-page application. Top-level `/login` and `/app/*` rewrites select the service and set its runtime-visible request path to `/index.html`, while the final catch-all preserves normal web asset and root paths.
 - `api` builds `Dockerfile.vercel` as a Rust container and receives `/auth/*`, `/graphql`, `/health`, `/sync/*`, `/bookmarks`, `/categories`, and `/explore*`.
-- `apps/web/vercel.json` keeps the Vite app's standalone SPA fallback; Vercel Services additionally requires the top-level web-service route selection above.
+- `apps/web/vercel.json` keeps the Vite app's standalone SPA fallback. In Services mode that nested file is not the public router, so the top-level request-path transforms above own direct React entry points.
 
 The linked Vercel project's Framework Preset must be set to **Services**. Vercel only activates this topology when that project setting and the top-level `services` configuration are both present. Automatic Vercel Git deployments are disabled in `vercel.json`; the protected, main-only release workflow owns production builds and domain updates.
 

--- a/docs/ui-login-flow.md
+++ b/docs/ui-login-flow.md
@@ -97,7 +97,7 @@ The authenticated shell has three primary areas: Explore, Saved, and Settings. S
 
 - `apps/web/src/`: React routes, authentication boundary, query state, and product composition
 - `apps/web/vite.config.ts`: development API proxy and browser-test configuration
-- `vercel.json`: production Services routing, including direct `/login` and `/app/*` SPA entry points
+- `vercel.json`: production Services routing, including direct `/login` and `/app/*` request-path transforms to the SPA entry point
 - `apps/web/vercel.json`: standalone Vite SPA fallback
 - `packages/api_client/src/index.ts`: credentialed REST/GraphQL client and OAuth URL helper
 - `src/http.rs`: OAuth routes, cookie creation/resolution, CORS, GraphQL routing

--- a/vercel.json
+++ b/vercel.json
@@ -62,11 +62,25 @@
     },
     {
       "source": "/login",
-      "destination": { "service": "web", "path": "/index.html" }
+      "destination": { "service": "web" },
+      "transforms": [
+        {
+          "type": "request.path",
+          "op": "set",
+          "args": "/index.html"
+        }
+      ]
     },
     {
       "source": "/app/(.*)",
-      "destination": { "service": "web", "path": "/index.html" }
+      "destination": { "service": "web" },
+      "transforms": [
+        {
+          "type": "request.path",
+          "op": "set",
+          "args": "/index.html"
+        }
+      ]
     },
     {
       "source": "/(.*)",


### PR DESCRIPTION
## What changed

- replace Vercel Services `destination.path` selectors with explicit `request.path` transforms for `/login` and `/app/*`
- preserve the plain web catch-all so root and static asset paths remain unchanged
- update the production contract and deployment documentation

## Why

`destination.path` only selects a route inside the target service; it does not change the path seen by the static Vite service. Because the web service has no internal `/login` or `/app/*` files, direct navigation returned 404 even though `/index.html` existed.

## Impact

Direct React entry URLs now resolve to `index.html`, while API routes and real JavaScript/CSS assets keep their original paths.

## Validation

- `pnpm check`
- `pnpm production:check`
- `git diff --check`
- Ribbon GitExplore profile: 15/15 checks passed
- Vercel production/preview builds generated the expected `request.path -> /index.html` transforms
