### PR TITLE
Move SPA fallback into web service

### DIFF
--- a/.github/scripts/verify-production-contract.mjs
+++ b/.github/scripts/verify-production-contract.mjs
@@ -62,6 +62,12 @@ requireContract(
 
 requireContract(vercel.services?.web?.framework === 'vite', 'Vercel web service must use Vite');
 requireContract(
+  vercel.services?.web?.rewrites?.some(
+    (rewrite) => rewrite.source === '/(.*)' && rewrite.destination === '/index.html'
+  ),
+  'Vercel web service must own the SPA fallback to index.html'
+);
+requireContract(
   vercel.git?.deploymentEnabled === false,
   'Automatic Vercel Git deployments must stay disabled; the protected release workflow owns production'
 );
@@ -83,23 +89,20 @@ for (const route of ['/auth/(.*)', '/graphql', '/health']) {
     `Vercel API rewrite missing for ${route}`
   );
 }
-for (const route of ['/login', '/app/(.*)']) {
-  requireContract(
-    vercel.rewrites?.some(
-      (rewrite) =>
-        rewrite.source === route &&
-        rewrite.destination?.service === 'web' &&
-        rewrite.destination.path === undefined &&
-        rewrite.transforms?.some(
-          (transform) =>
-            transform.type === 'request.path' &&
-            transform.op === 'set' &&
-            transform.args === '/index.html'
-        )
-    ),
-    `Vercel SPA request-path transform missing for ${route}`
-  );
-}
+requireContract(
+  vercel.rewrites?.some(
+    (rewrite) => rewrite.source === '/(.*)' && rewrite.destination?.service === 'web'
+  ),
+  'Vercel web service catch-all is missing'
+);
+requireContract(
+  !vercel.rewrites?.some(
+    (rewrite) =>
+      rewrite.destination?.service === 'web' &&
+      (rewrite.destination.path !== undefined || rewrite.transforms !== undefined)
+  ),
+  'Top-level web handoffs must preserve the request for service-local SPA routing'
+);
 for (const header of [
   'Content-Security-Policy',
   'Strict-Transport-Security',

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,9 +8,9 @@ This document describes the deployment scaffold. It does not claim that the prod
 
 `vercel.json` declares two services:
 
-- `web` builds the React/Vite single-page application. Top-level `/login` and `/app/*` rewrites select the service and set its runtime-visible request path to `/index.html`, while the final catch-all preserves normal web asset and root paths.
+- `web` builds the React/Vite single-page application. Its service-local rewrite checks the real filesystem first and then falls back to `/index.html`, so direct `/login` and `/app/*` requests reach React without turning JavaScript or CSS requests into HTML.
 - `api` builds `Dockerfile.vercel` as a Rust container and receives `/auth/*`, `/graphql`, `/health`, `/sync/*`, `/bookmarks`, `/categories`, and `/explore*`.
-- `apps/web/vercel.json` keeps the Vite app's standalone SPA fallback. In Services mode that nested file is not the public router, so the top-level request-path transforms above own direct React entry points.
+- The final top-level catch-all selects `web` without changing the request path. `services.web.rewrites` owns the Services-mode SPA fallback; `apps/web/vercel.json` keeps the same fallback when the Vite app is deployed standalone.
 
 The linked Vercel project's Framework Preset must be set to **Services**. Vercel only activates this topology when that project setting and the top-level `services` configuration are both present. Automatic Vercel Git deployments are disabled in `vercel.json`; the protected, main-only release workflow owns production builds and domain updates.
 

--- a/docs/ui-login-flow.md
+++ b/docs/ui-login-flow.md
@@ -97,7 +97,7 @@ The authenticated shell has three primary areas: Explore, Saved, and Settings. S
 
 - `apps/web/src/`: React routes, authentication boundary, query state, and product composition
 - `apps/web/vite.config.ts`: development API proxy and browser-test configuration
-- `vercel.json`: production Services routing, including direct `/login` and `/app/*` request-path transforms to the SPA entry point
+- `vercel.json`: production Services routing, including the web service's filesystem-first SPA fallback for direct `/login` and `/app/*` entry points
 - `apps/web/vercel.json`: standalone Vite SPA fallback
 - `packages/api_client/src/index.ts`: credentialed REST/GraphQL client and OAuth URL helper
 - `src/http.rs`: OAuth routes, cookie creation/resolution, CORS, GraphQL routing

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,13 @@
   "services": {
     "web": {
       "root": "apps/web/",
-      "framework": "vite"
+      "framework": "vite",
+      "rewrites": [
+        {
+          "source": "/(.*)",
+          "destination": "/index.html"
+        }
+      ]
     },
     "api": {
       "root": ".",
@@ -59,28 +65,6 @@
     {
       "source": "/explore",
       "destination": { "service": "api" }
-    },
-    {
-      "source": "/login",
-      "destination": { "service": "web" },
-      "transforms": [
-        {
-          "type": "request.path",
-          "op": "set",
-          "args": "/index.html"
-        }
-      ]
-    },
-    {
-      "source": "/app/(.*)",
-      "destination": { "service": "web" },
-      "transforms": [
-        {
-          "type": "request.path",
-          "op": "set",
-          "args": "/index.html"
-        }
-      ]
     },
     {
       "source": "/(.*)",


### PR DESCRIPTION
## What changed

- move the Vite SPA fallback into `services.web.rewrites`
- keep the top-level web handoff path-preserving and after all API routes
- update the production contract and deployment documentation

## Root cause

Vercel Services treats top-level service routing as a terminal handoff. Neither `destination.path` nor a top-level `request.path` transform made the static Vite service resolve `/login` or `/app/*` as `index.html`; both variants deployed successfully but remained 404 in production. The web service therefore needs its own filesystem-first fallback route.

The generated web service config is now:

```json
[
  { "handle": "filesystem" },
  { "src": "^(?:/(.*))$", "dest": "/index.html", "check": true }
]
```

That preserves real JS/CSS files and serves React for deep links.

## Validation

- `pnpm production:check`
- `pnpm check`
- `git diff --check`
- `vercel build` succeeds
- generated `.vercel/output/services/web/config.json` contains filesystem-first SPA fallback
