### PR TITLE
Accept pnpm separator in live smoke

### DIFF
--- a/.github/scripts/verify-live-frontend.mjs
+++ b/.github/scripts/verify-live-frontend.mjs
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import { chromium } from '@playwright/test';
 
-const rawBaseUrl = process.argv[2] ?? process.env.GITEXPLORE_SMOKE_BASE_URL;
+const rawBaseUrl = process.argv.slice(2).find((argument) => argument !== '--')
+  ?? process.env.GITEXPLORE_SMOKE_BASE_URL;
 assert(rawBaseUrl, 'Usage: pnpm production:smoke -- <base-url>');
 
 const baseUrl = new URL(rawBaseUrl);


### PR DESCRIPTION
## What changed

Ignore a literal `--` separator when selecting the live smoke test's base URL.

## Why

On the Linux release runner, `pnpm production:smoke -- https://gitexplore.moriatz.com` forwarded `--` to Node. The deployed app and all canonical curl checks passed, but the smoke script tried to parse `--` as a URL and failed before launching Chromium.

## Validation

- `node .github/scripts/verify-live-frontend.mjs -- https://gitexplore.moriatz.com`
- `pnpm production:smoke -- https://gitexplore.moriatz.com`
- `pnpm production:check`
- `git diff --check`

Both live browser invocations pass against production.
