### PR TITLE
Add first-value onboarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,20 @@ jobs:
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Restore Playwright Chromium cache
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-${{ runner.arch }}-playwright-1.61.1-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Chromium operating-system dependencies
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Install pinned Chromium browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install chromium
+
       - name: Verify Rust service
         run: |
           cargo fmt --check
@@ -101,6 +115,7 @@ jobs:
         run: |
           pnpm --filter @gitexplore/api-client test
           pnpm --filter @gitexplore/web test
+          pnpm --filter @gitexplore/web test:e2e
           pnpm check
 
       - name: Verify production contract and web build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
           pnpm --filter @gitexplore/api-client test
           pnpm --filter @gitexplore/web check
           pnpm --filter @gitexplore/web test
+          pnpm --filter @gitexplore/web test:e2e
           pnpm check
 
       - name: Enforce production contract

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 node_modules/
 .turbo/
 apps/web/dist/
+apps/web/test-results/
+apps/web/playwright-report/
 apps/web/.vercel/
 .vercel/
 .gitexplore-*.png

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -30,6 +30,8 @@ Docker Compose supplies `http://gitexplore:4000` as that proxy target inside its
 
 The router redirects the former bookmarks, categories, snapshots, and sync URLs into the matching Saved or Settings view.
 
+Authenticated routes share a versioned first-value onboarding provider. The non-blocking guide tracks real profile visits, valid connection trails, and repository saves through cookie-authenticated GraphQL state. It can be skipped or replayed from Settings, and its optional discovery mapping action never runs without an explicit click.
+
 ## Verify and build
 
 ```bash

--- a/apps/web/e2e/onboarding.spec.ts
+++ b/apps/web/e2e/onboarding.spec.ts
@@ -1,0 +1,171 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page } from '@playwright/test';
+
+type Progress = {
+  version: number;
+  status: 'NOT_STARTED' | 'IN_PROGRESS' | 'COMPLETED' | 'DISMISSED';
+  startedAt: string | null;
+  completedAt: string | null;
+  dismissedAt: string | null;
+  openedTrailhead: boolean;
+  followedConnection: boolean;
+  savedRepository: boolean;
+  mappingStarted: boolean;
+};
+
+const alice = {
+  githubId: '1', login: 'alice', name: 'Alice', url: 'https://github.com/alice',
+  avatarUrl: null, bio: 'Builds graph tools.', followersCount: 12, followingCount: 8,
+};
+const bob = {
+  githubId: '2', login: 'bob', name: 'Bob', url: 'https://github.com/bob',
+  avatarUrl: null, bio: 'Maintains useful things.', followersCount: 20, followingCount: 11,
+};
+const repository = {
+  githubId: '10', ownerLogin: 'acme', name: 'trail-map', fullName: 'acme/trail-map',
+  description: 'A small tool for navigating open source.', htmlUrl: 'https://github.com/acme/trail-map',
+  stargazerCount: 84, forkCount: 6, primaryLanguage: 'Rust', topics: ['graph'],
+  updatedAt: '2026-08-01T09:00:00Z', archived: false, fork: false,
+};
+
+function neighborhood(user: typeof alice, withRepository: boolean) {
+  return {
+    user,
+    followers: user.login === 'alice' ? [bob] : [],
+    following: [],
+    repositories: withRepository ? [{
+      repository,
+      networkStars: 3,
+      viaLogins: ['bob'],
+      discoveryScore: 42,
+      reasons: ['Starred by people near this trail'],
+      saved: false,
+    }] : [],
+    cacheStatus: 'FRESH',
+    lastFetchedAt: '2026-08-01T09:00:00Z',
+    coverage: {
+      followersComplete: true,
+      followingComplete: true,
+      starredRepositoriesComplete: true,
+      repositoriesComplete: true,
+    },
+  };
+}
+
+async function mockGitExplore(page: Page) {
+  const startedAt = '2026-08-01T10:00:00Z';
+  const visits: Array<{ user: typeof alice; trail: string[]; direction: 'FOLLOWERS' | 'FOLLOWING'; lastViewedAt: string; visitCount: number; visible: boolean }> = [];
+  let saved = false;
+  let progress: Progress = {
+    version: 1,
+    status: 'NOT_STARTED',
+    startedAt: null,
+    completedAt: null,
+    dismissedAt: null,
+    openedTrailhead: false,
+    followedConnection: false,
+    savedRepository: false,
+    mappingStarted: false,
+  };
+
+  await page.route('**/auth/status', (route) => route.fulfill({
+    json: {
+      authenticated: true,
+      app_user_id: 'app-user-1',
+      connected: true,
+      account: { github_user_id: 1, login: 'alice', display_name: 'Alice' },
+    },
+  }));
+  await page.route('**/bookmarks', async (route, request) => {
+    if (request.method() === 'GET') {
+      await route.fulfill({ json: saved ? [{
+        id: 'bookmark-1',
+        target: { GitHubRepository: { full_name: repository.fullName } },
+        categories: [],
+        note: null,
+        created_at: '2026-08-01T10:05:00Z',
+      }] : [] });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.route('**/categories', (route) => route.fulfill({ json: [] }));
+  await page.route('**/graphql', async (route, request) => {
+    const body = request.postDataJSON() as { query: string; variables: Record<string, unknown> };
+    const query = body.query;
+    let data: Record<string, unknown>;
+
+    if (query.includes('mutation BeginOnboarding')) {
+      progress = { ...progress, status: 'IN_PROGRESS', startedAt };
+      data = { beginOnboarding: progress };
+    } else if (query.includes('mutation DismissOnboarding')) {
+      progress = { ...progress, status: 'DISMISSED', dismissedAt: '2026-08-01T10:01:00Z' };
+      data = { dismissOnboarding: progress };
+    } else if (query.includes('mutation CompleteOnboarding')) {
+      progress = { ...progress, status: 'COMPLETED', completedAt: '2026-08-01T10:05:00Z' };
+      data = { completeOnboarding: progress };
+    } else if (query.includes('query OnboardingProgress')) {
+      data = { onboardingProgress: progress };
+    } else if (query.includes('query DiscoveryWarmup')) {
+      data = { discoveryWarmup: null };
+    } else if (query.includes('query RateLimit')) {
+      data = { rateLimit: { limit: 5000, used: 800, remaining: 4200, resetAt: '2026-08-01T11:00:00Z', checkedAt: startedAt } };
+    } else if (query.includes('mutation RecordPersonVisit')) {
+      const login = String(body.variables.login);
+      const user = login === 'alice' ? alice : bob;
+      const trail = body.variables.trail as string[];
+      visits.unshift({ user, trail, direction: String(body.variables.direction) as 'FOLLOWERS' | 'FOLLOWING', lastViewedAt: '2026-08-01T10:02:00Z', visitCount: 1, visible: true });
+      progress = {
+        ...progress,
+        openedTrailhead: visits.length > 0,
+        followedConnection: visits.some((visit) => visit.trail.length >= 2),
+      };
+      data = { recordPersonVisit: { recentPeople: visits, maxTrailDepth: progress.followedConnection ? 1 : 0 } };
+    } else if (query.includes('query ExplorationActivity')) {
+      data = { explorationActivity: { recentPeople: visits, maxTrailDepth: progress.followedConnection ? 1 : 0 } };
+    } else if (query.includes('query Neighborhood')) {
+      const login = String(body.variables.login);
+      data = { neighborhood: neighborhood(login === 'alice' ? alice : bob, login === 'bob') };
+    } else if (query.includes('mutation SaveRepository')) {
+      saved = true;
+      progress = { ...progress, savedRepository: true };
+      data = { saveRepository: { id: 'bookmark-1', fullName: repository.fullName, categories: [], note: null, createdAt: '2026-08-01T10:05:00Z' } };
+    } else if (query.includes('query UserInsights')) {
+      data = { userInsights: { login: String(body.variables.login), repositories: [], windowDays: 90, sourceEventCount: 0, sourceTruncated: false, sourceDescription: 'Public events', cacheStatus: 'FRESH', lastFetchedAt: startedAt } };
+    } else {
+      throw new Error(`Unhandled GraphQL operation: ${query}`);
+    }
+    await route.fulfill({ json: { data } });
+  });
+}
+
+test('connected user reaches a private first save through the onboarding trail', async ({ page }) => {
+  await mockGitExplore(page);
+  await page.goto('/app/explore');
+
+  await expect(page.getByRole('heading', { name: 'Your first GitExplore trail' })).toBeVisible();
+  expect((await new AxeBuilder({ page }).include('.onboarding-card').analyze()).violations).toEqual([]);
+
+  await page.getByRole('link', { name: 'Start from @alice' }).click();
+  await expect(page.getByRole('heading', { name: 'Alice' })).toBeVisible();
+  await page.getByRole('link', { name: /Bob @bob/ }).click();
+  await expect(page.getByRole('heading', { name: 'Bob' })).toBeVisible();
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  await expect(page.getByText('Your first find is saved')).toBeVisible();
+  expect((await new AxeBuilder({ page }).include('#main-content').analyze()).violations).toEqual([]);
+  await page.getByRole('link', { name: 'Open Saved' }).click();
+  await expect(page.getByRole('heading', { name: 'Saved' })).toBeVisible();
+  await expect(page.getByText('acme/trail-map')).toBeVisible();
+});
+
+test('skip remains dismissed after a reload', async ({ page }) => {
+  await mockGitExplore(page);
+  await page.goto('/app/explore');
+
+  await page.getByRole('button', { name: 'Skip onboarding' }).click();
+  await expect(page.getByRole('heading', { name: 'Your first GitExplore trail' })).toBeHidden();
+  await page.reload();
+  await expect(page.getByRole('heading', { name: 'Your first GitExplore trail' })).toBeHidden();
+  await expect(page.getByRole('heading', { name: /Whose GitHub world/ })).toBeVisible();
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview --host 0.0.0.0 --port 3000",
     "check": "tsc --noEmit",
     "lint": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test --config=playwright.config.ts"
   },
   "dependencies": {
     "@fontsource-variable/bricolage-grotesque": "5.3.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:3000',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -5,6 +5,8 @@ import { BookmarkIcon, GitHubIcon, SearchIcon, SettingsIcon } from 'strawn-icons
 
 import { api } from '../api';
 import { useAuth } from '../auth';
+import { OnboardingProvider } from '../onboarding';
+import { OnboardingChecklist, OnboardingCompletion } from './OnboardingChecklist';
 
 const navItems = [
   { to: '/app/explore', label: 'Explore', icon: SearchIcon },
@@ -13,6 +15,10 @@ const navItems = [
 ] as const;
 
 export function AppShell() {
+  return <OnboardingProvider><AppShellContent /></OnboardingProvider>;
+}
+
+function AppShellContent() {
   const { status } = useAuth();
   const rateQuery = useQuery({
     queryKey: ['github-rate-limit'],
@@ -65,7 +71,11 @@ export function AppShell() {
         </Link>
         {rateQuery.data ? <span className="numeric-caption">{rateQuery.data.remaining.toLocaleString()} requests</span> : null}
       </header>
-      <main id="main-content" className="app-main" tabIndex={-1}><Outlet /></main>
+      <main id="main-content" className="app-main" tabIndex={-1}>
+        <OnboardingCompletion />
+        <OnboardingChecklist />
+        <Outlet />
+      </main>
       <nav className="mobile-nav" aria-label="Primary">
         {navItems.map(({ to, label, icon: Icon }) => (
           <NavLink key={to} to={to} className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>

--- a/apps/web/src/components/OnboardingChecklist.test.tsx
+++ b/apps/web/src/components/OnboardingChecklist.test.tsx
@@ -1,0 +1,125 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from 'strawn';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const api = vi.hoisted(() => ({
+  getOnboardingProgress: vi.fn(),
+  beginOnboarding: vi.fn(),
+  dismissOnboarding: vi.fn(),
+  restartOnboarding: vi.fn(),
+  completeOnboarding: vi.fn(),
+  getDiscoveryWarmup: vi.fn(),
+  getRateLimit: vi.fn(),
+  startDiscoveryWarmup: vi.fn(),
+}));
+
+vi.mock('../api', () => ({ api }));
+vi.mock('../auth', () => ({
+  useAuth: () => ({
+    status: { account: { login: 'alice', display_name: 'Alice' } },
+  }),
+}));
+
+import { OnboardingProvider } from '../onboarding';
+import { OnboardingChecklist, OnboardingCompletion } from './OnboardingChecklist';
+
+const notStarted = {
+  version: 1,
+  status: 'NOT_STARTED' as const,
+  startedAt: null,
+  completedAt: null,
+  dismissedAt: null,
+  openedTrailhead: false,
+  followedConnection: false,
+  savedRepository: false,
+  mappingStarted: false,
+};
+
+const inProgress = {
+  ...notStarted,
+  status: 'IN_PROGRESS' as const,
+  startedAt: '2026-08-01T10:00:00Z',
+};
+
+function renderOnboarding() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/app/explore']}>
+          <OnboardingProvider>
+            <OnboardingCompletion />
+            <OnboardingChecklist />
+          </OnboardingProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe('OnboardingChecklist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getOnboardingProgress.mockResolvedValue(notStarted);
+    api.beginOnboarding.mockResolvedValue(inProgress);
+    api.dismissOnboarding.mockResolvedValue({ ...inProgress, status: 'DISMISSED' });
+    api.completeOnboarding.mockResolvedValue({ ...inProgress, status: 'COMPLETED' });
+    api.getDiscoveryWarmup.mockResolvedValue(null);
+    api.getRateLimit.mockResolvedValue({
+      limit: 5000,
+      used: 800,
+      remaining: 4200,
+      resetAt: '2026-08-01T11:00:00Z',
+      checkedAt: '2026-08-01T10:00:00Z',
+    });
+    api.startDiscoveryWarmup.mockResolvedValue({
+      id: 'warmup-1', seedLogin: 'alice', status: 'QUEUED', currentLogin: null,
+      expandedUsers: 0, discoveredUsers: 1, pendingUsers: 1, frontierTruncated: false,
+      remainingRequests: 4200, reserveRequests: 1000, resetAt: null,
+      startedAt: '2026-08-01T10:00:00Z', updatedAt: '2026-08-01T10:00:00Z',
+      completedAt: null, lastError: null,
+    });
+  });
+
+  it('begins once, recommends the connected trailhead, and keeps mapping opt-in', async () => {
+    const user = userEvent.setup();
+    renderOnboarding();
+
+    expect(await screen.findByRole('heading', { name: 'Your first GitExplore trail' })).toBeInTheDocument();
+    await waitFor(() => expect(api.beginOnboarding).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('link', { name: /start from @alice/i })).toHaveAttribute('href', '/app/explore/alice?trail=alice');
+    expect(api.startDiscoveryWarmup).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Start mapping' }));
+    expect(api.startDiscoveryWarmup).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('Mapping network')).toBeInTheDocument();
+  });
+
+  it('persists an explicit skip', async () => {
+    const user = userEvent.setup();
+    api.getOnboardingProgress.mockResolvedValue(inProgress);
+    renderOnboarding();
+
+    await user.click(await screen.findByRole('button', { name: 'Skip onboarding' }));
+    await waitFor(() => expect(api.dismissOnboarding).toHaveBeenCalledTimes(1));
+  });
+
+  it('completes only after all real-action flags are present', async () => {
+    api.getOnboardingProgress.mockResolvedValue({
+      ...inProgress,
+      openedTrailhead: true,
+      followedConnection: true,
+      savedRepository: true,
+    });
+    renderOnboarding();
+
+    await waitFor(() => expect(api.completeOnboarding).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('Your first find is saved')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open Saved' })).toHaveAttribute('href', '/app/saved');
+  });
+});

--- a/apps/web/src/components/OnboardingChecklist.tsx
+++ b/apps/web/src/components/OnboardingChecklist.tsx
@@ -1,0 +1,234 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { Alert, Badge, Button, Heading, Progress, Skeleton, Surface, Text } from 'strawn';
+import {
+  ArrowRightIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  CircleAlertIcon,
+  DatabaseIcon,
+  MapPinIcon,
+} from 'strawn-icons';
+
+import { api } from '../api';
+import { useAuth } from '../auth';
+import { buildExploreHref } from '../lib/graph-navigation';
+import { formatTimestamp } from '../lib/format';
+import { onboardingQueryKey, type OnboardingStep, useOnboarding } from '../onboarding';
+
+const steps: Array<{ key: OnboardingStep; label: string; detail: string }> = [
+  { key: 'trailhead', label: 'Open a trailhead', detail: 'Start from a real GitHub profile.' },
+  { key: 'connection', label: 'Follow one connection', detail: 'Walk through a follower or maintainer.' },
+  { key: 'repository', label: 'Save a repository', detail: 'Keep one ranked find in your private notebook.' },
+];
+
+function stepComplete(key: OnboardingStep, progress: NonNullable<ReturnType<typeof useOnboarding>['progress']>) {
+  if (key === 'trailhead') return progress.openedTrailhead;
+  if (key === 'connection') return progress.followedConnection;
+  return progress.savedRepository;
+}
+
+function CurrentStepAction({ step, login }: { step: OnboardingStep | null; login: string }) {
+  const location = useLocation();
+  const onUserPage = /^\/app\/explore\/[^/]+/.test(location.pathname);
+  if (step === 'trailhead') {
+    return (
+      <Link className="primary-link onboarding-action" to={buildExploreHref(login)}>
+        Start from @{login} <ArrowRightIcon aria-hidden="true" size={16} />
+      </Link>
+    );
+  }
+  if (step === 'connection' && onUserPage) {
+    return <a className="primary-link onboarding-action" href="#connections">Choose a connection <ArrowRightIcon aria-hidden="true" size={16} /></a>;
+  }
+  if (step === 'repository' && onUserPage) {
+    return <a className="primary-link onboarding-action" href="#discoveries">See ranked repositories <ArrowRightIcon aria-hidden="true" size={16} /></a>;
+  }
+  return (
+    <Link className="primary-link onboarding-action" to={buildExploreHref(login)}>
+      Return to your graph <ArrowRightIcon aria-hidden="true" size={16} />
+    </Link>
+  );
+}
+
+function MappingOption() {
+  const queryClient = useQueryClient();
+  const { refreshProgress } = useOnboarding();
+  const warmupQuery = useQuery({
+    queryKey: ['discovery-warmup'],
+    queryFn: () => api.getDiscoveryWarmup(),
+    retry: false,
+    refetchInterval: (query) => ['QUEUED', 'RUNNING'].includes(query.state.data?.status ?? '') ? 2_500 : false,
+  });
+  const rateQuery = useQuery({
+    queryKey: ['github-rate-limit'],
+    queryFn: () => api.getRateLimit(),
+    staleTime: 60_000,
+    retry: 1,
+  });
+  const warmupMutation = useMutation({
+    mutationFn: () => api.startDiscoveryWarmup(),
+    onSuccess: async (warmup) => {
+      queryClient.setQueryData(['discovery-warmup'], warmup);
+      await Promise.all([
+        refreshProgress(),
+        queryClient.invalidateQueries({ queryKey: ['github-rate-limit'] }),
+      ]);
+    },
+    retry: false,
+  });
+  const warmup = warmupQuery.data;
+  const total = warmup ? Math.max(warmup.discoveredUsers, warmup.expandedUsers + warmup.pendingUsers, 1) : 1;
+
+  return (
+    <div className="onboarding-mapping">
+      <div className="onboarding-mapping-copy">
+        <span className="onboarding-mapping-icon" aria-hidden="true"><DatabaseIcon size={17} /></span>
+        <div>
+          <strong>Warm your discovery map</strong>
+          <Text size="xs" color="$mutedForeground">
+            Optional. Map outward in the background while GitExplore preserves 1,000 GitHub requests.
+          </Text>
+        </div>
+      </div>
+      {warmupQuery.isPending ? <Skeleton height="2.75rem" /> : null}
+      {!warmupQuery.isPending && !warmup ? (
+        <div className="onboarding-mapping-action">
+          <span className="numeric-caption">
+            {rateQuery.data ? `${rateQuery.data.remaining.toLocaleString()} requests available` : 'The reserve is enforced before every request'}
+          </span>
+          <Button size="sm" variant="outline" loading={warmupMutation.isPending} onClick={() => warmupMutation.mutate()}>
+            Start mapping
+          </Button>
+        </div>
+      ) : null}
+      {warmup ? (
+        <div className="onboarding-mapping-progress" role="status" aria-live="polite">
+          <div><strong>{warmup.status === 'COMPLETED' ? 'Map is warm' : warmup.status === 'RESERVE_PROTECTED' ? 'Reserve protected' : warmup.status === 'FAILED' ? 'Mapping paused' : 'Mapping network'}</strong><Badge tone={warmup.status === 'FAILED' ? 'error' : warmup.status === 'RESERVE_PROTECTED' ? 'warning' : warmup.status === 'COMPLETED' ? 'success' : 'info'}>{warmup.status.replace('_', ' ').toLowerCase()}</Badge></div>
+          <Progress label="Discovery mapping progress" value={warmup.expandedUsers} max={total} size="sm" indeterminate={warmup.status === 'QUEUED' && warmup.expandedUsers === 0} />
+          {warmup.status === 'RESERVE_PROTECTED' ? <Text size="xs" color="$mutedForeground">Continue after {formatTimestamp(warmup.resetAt)}.</Text> : null}
+          {warmup.lastError ? <Text size="xs" color="$mutedForeground">{warmup.lastError}</Text> : null}
+        </div>
+      ) : null}
+      {warmupQuery.isError ? <Text size="xs" color="$mutedForeground">Mapping status is unavailable. Your onboarding can continue.</Text> : null}
+      {warmupMutation.isError ? <Alert tone="warning" title="Mapping did not start">{warmupMutation.error.message}</Alert> : null}
+    </div>
+  );
+}
+
+export function OnboardingChecklist() {
+  const [skipRequested, setSkipRequested] = useState(false);
+  const { status } = useAuth();
+  const {
+    progress,
+    loading,
+    error,
+    active,
+    collapsed,
+    currentStep,
+    dismissPending,
+    setCollapsed,
+    dismiss,
+    retry,
+  } = useOnboarding();
+  const login = status?.account?.login ?? '';
+
+  useEffect(() => {
+    if (error) setSkipRequested(false);
+  }, [error]);
+
+  if (skipRequested) return null;
+  if (!active && !error) return null;
+  if (loading && !progress) {
+    return <section className="onboarding-skeleton" aria-label="Loading onboarding" aria-busy="true"><Skeleton height="5rem" /></section>;
+  }
+  if (error && !progress) {
+    return (
+      <Alert
+        tone="warning"
+        title="Your onboarding guide is unavailable"
+        icon={<CircleAlertIcon aria-hidden="true" size={17} />}
+        action={<Button variant="outline" onClick={() => void retry()}>Retry</Button>}
+      >
+        GitExplore is still fully available.
+      </Alert>
+    );
+  }
+  if (!progress || !active) return null;
+
+  const completed = steps.filter((step) => stepComplete(step.key, progress)).length;
+  if (collapsed) {
+    return (
+      <button className="onboarding-collapsed" type="button" onClick={() => setCollapsed(false)} aria-expanded="false">
+        <MapPinIcon aria-hidden="true" size={17} />
+        <span><strong>Your first trail</strong><small>{completed} of 3 complete</small></span>
+        <ChevronDownIcon aria-hidden="true" size={16} />
+      </button>
+    );
+  }
+
+  return (
+    <Surface as="section" className="onboarding-card" tone="default" radius="lg" padding="lg" aria-labelledby="onboarding-title">
+      <div className="onboarding-header">
+        <div>
+          <Text size="xs" color="$mutedForeground">Field guide · {completed} of 3 complete</Text>
+          <Heading id="onboarding-title" size="h2">Your first GitExplore trail</Heading>
+          <Text size="sm" color="$mutedForeground">Find useful work through people you trust, then keep the find privately.</Text>
+        </div>
+        <Button variant="ghost" size="sm" rightIcon={<ChevronUpIcon aria-hidden="true" size={15} />} onClick={() => setCollapsed(true)} aria-expanded="true">
+          Collapse
+        </Button>
+      </div>
+      <Progress label={`${completed} of 3 onboarding steps complete`} value={completed} max={3} size="sm" />
+      <ol className="onboarding-steps">
+        {steps.map((step, index) => {
+          const done = stepComplete(step.key, progress);
+          const current = currentStep === step.key;
+          return (
+            <li key={step.key} className={done ? 'complete' : current ? 'current' : ''} aria-current={current ? 'step' : undefined}>
+              <span className="onboarding-step-marker" aria-hidden="true">{done ? <CheckIcon size={14} /> : index + 1}</span>
+              <span><strong>{step.label}</strong><small>{step.detail}</small></span>
+            </li>
+          );
+        })}
+      </ol>
+      <div className="onboarding-controls">
+        <CurrentStepAction step={currentStep} login={login} />
+        <Button
+          variant="ghost"
+          size="sm"
+          loading={dismissPending}
+          onClick={() => {
+            setSkipRequested(true);
+            dismiss();
+          }}
+        >
+          Skip onboarding
+        </Button>
+        <Text size="xs" color="$mutedForeground">Replay it any time from Settings.</Text>
+      </div>
+      <MappingOption />
+    </Surface>
+  );
+}
+
+export function OnboardingCompletion() {
+  const { completionVisible, hideCompletion } = useOnboarding();
+  if (!completionVisible) return null;
+  return (
+    <Alert
+      tone="success"
+      title="Your first find is saved"
+      action={(
+        <div className="onboarding-completion-actions">
+          <Link className="secondary-link" to="/app/saved" onClick={hideCompletion}>Open Saved</Link>
+          <Button variant="ghost" size="sm" onClick={hideCompletion}>Keep exploring</Button>
+        </div>
+      )}
+    >
+      The repository is in your private field notebook. Follow another signal whenever you are ready.
+    </Alert>
+  );
+}

--- a/apps/web/src/onboarding.tsx
+++ b/apps/web/src/onboarding.tsx
@@ -1,0 +1,195 @@
+import type { OnboardingProgress } from '@gitexplore/api-client';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { api } from './api';
+
+export const onboardingQueryKey = ['onboarding-progress'] as const;
+
+export type OnboardingStep = 'trailhead' | 'connection' | 'repository';
+
+type OnboardingContextValue = {
+  progress: OnboardingProgress | undefined;
+  loading: boolean;
+  error: Error | null;
+  active: boolean;
+  collapsed: boolean;
+  completionVisible: boolean;
+  currentStep: OnboardingStep | null;
+  dismissPending: boolean;
+  restartPending: boolean;
+  setCollapsed: (collapsed: boolean) => void;
+  dismiss: () => void;
+  restart: () => Promise<OnboardingProgress>;
+  retry: () => Promise<unknown>;
+  refreshProgress: () => Promise<unknown>;
+  hideCompletion: () => void;
+};
+
+const unavailableOnboarding: OnboardingContextValue = {
+  progress: undefined,
+  loading: false,
+  error: null,
+  active: false,
+  collapsed: false,
+  completionVisible: false,
+  currentStep: null,
+  dismissPending: false,
+  restartPending: false,
+  setCollapsed: () => undefined,
+  dismiss: () => undefined,
+  restart: async () => { throw new Error('Onboarding is unavailable outside the app shell.'); },
+  retry: async () => undefined,
+  refreshProgress: async () => undefined,
+  hideCompletion: () => undefined,
+};
+
+const OnboardingContext = createContext<OnboardingContextValue>(unavailableOnboarding);
+
+function requiredStepsComplete(progress: OnboardingProgress) {
+  return progress.openedTrailhead
+    && progress.followedConnection
+    && progress.savedRepository;
+}
+
+export function currentOnboardingStep(
+  progress: OnboardingProgress | undefined,
+): OnboardingStep | null {
+  if (!progress?.openedTrailhead) return 'trailhead';
+  if (!progress.followedConnection) return 'connection';
+  if (!progress.savedRepository) return 'repository';
+  return null;
+}
+
+export function OnboardingProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
+  const attemptedBegin = useRef(false);
+  const attemptedCompletion = useRef(false);
+  const [collapsed, setCollapsed] = useState(false);
+  const [completionVisible, setCompletionVisible] = useState(false);
+  const [locallyDismissed, setLocallyDismissed] = useState(false);
+
+  const progressQuery = useQuery({
+    queryKey: onboardingQueryKey,
+    queryFn: () => api.getOnboardingProgress(),
+    retry: false,
+  });
+  const beginMutation = useMutation({
+    mutationFn: () => api.beginOnboarding(),
+    onSuccess: (progress) => queryClient.setQueryData(onboardingQueryKey, progress),
+    retry: false,
+  });
+  const dismissMutation = useMutation({
+    mutationFn: () => api.dismissOnboarding(),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: onboardingQueryKey });
+      const previous = queryClient.getQueryData<OnboardingProgress>(onboardingQueryKey);
+      if (previous) {
+        queryClient.setQueryData(onboardingQueryKey, {
+          ...previous,
+          status: 'DISMISSED',
+          dismissedAt: new Date().toISOString(),
+        });
+      }
+      return { previous };
+    },
+    onSuccess: (progress) => queryClient.setQueryData(onboardingQueryKey, progress),
+    onError: (_error, _variables, context) => {
+      setLocallyDismissed(false);
+      if (context?.previous) queryClient.setQueryData(onboardingQueryKey, context.previous);
+    },
+    retry: false,
+  });
+  const restartMutation = useMutation({
+    mutationFn: () => api.restartOnboarding(),
+    onSuccess: (progress) => {
+      queryClient.setQueryData(onboardingQueryKey, progress);
+      setCollapsed(false);
+      setCompletionVisible(false);
+      setLocallyDismissed(false);
+    },
+    retry: false,
+  });
+  const completeMutation = useMutation({
+    mutationFn: () => api.completeOnboarding(),
+    onSuccess: (progress) => {
+      queryClient.setQueryData(onboardingQueryKey, progress);
+      setCompletionVisible(true);
+    },
+    retry: false,
+  });
+
+  const progress = progressQuery.data;
+  useEffect(() => {
+    if (progress?.status !== 'NOT_STARTED' || attemptedBegin.current) return;
+    attemptedBegin.current = true;
+    beginMutation.mutate();
+  }, [beginMutation, progress?.status]);
+
+  useEffect(() => {
+    if (progress?.status !== 'IN_PROGRESS' || !requiredStepsComplete(progress)) {
+      attemptedCompletion.current = false;
+      return;
+    }
+    if (attemptedCompletion.current) return;
+    attemptedCompletion.current = true;
+    completeMutation.mutate();
+  }, [completeMutation, progress]);
+
+  const active = !locallyDismissed
+    && (progress?.status === 'NOT_STARTED' || progress?.status === 'IN_PROGRESS');
+  const errorValue = progressQuery.error
+    ?? beginMutation.error
+    ?? dismissMutation.error
+    ?? restartMutation.error
+    ?? completeMutation.error;
+  const value = useMemo<OnboardingContextValue>(() => ({
+    progress,
+    loading: progressQuery.isPending || beginMutation.isPending,
+    error: errorValue instanceof Error ? errorValue : null,
+    active,
+    collapsed,
+    completionVisible,
+    currentStep: currentOnboardingStep(progress),
+    dismissPending: dismissMutation.isPending,
+    restartPending: restartMutation.isPending,
+    setCollapsed,
+    dismiss: () => {
+      setLocallyDismissed(true);
+      dismissMutation.mutate();
+    },
+    restart: () => restartMutation.mutateAsync(),
+    retry: async () => {
+      attemptedBegin.current = false;
+      return progressQuery.refetch();
+    },
+    refreshProgress: () => queryClient.invalidateQueries({ queryKey: onboardingQueryKey }),
+    hideCompletion: () => setCompletionVisible(false),
+  }), [
+    active,
+    beginMutation.isPending,
+    collapsed,
+    completionVisible,
+    dismissMutation,
+    errorValue,
+    progress,
+    progressQuery,
+    queryClient,
+    restartMutation,
+    locallyDismissed,
+  ]);
+
+  return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>;
+}
+
+export function useOnboarding() {
+  return useContext(OnboardingContext);
+}

--- a/apps/web/src/pages/ExploreStartPage.tsx
+++ b/apps/web/src/pages/ExploreStartPage.tsx
@@ -7,12 +7,14 @@ import { ArrowRightIcon, CircleAlertIcon, GitHubIcon, UsersIcon } from 'strawn-i
 import { api } from '../api';
 import { useAuth } from '../auth';
 import { buildExploreHref, isLikelyGitHubLogin, normalizeLoginInput } from '../lib/graph-navigation';
+import { useOnboarding } from '../onboarding';
 import { useDocumentTitle } from '../useDocumentTitle';
 
 export function ExploreStartPage() {
   useDocumentTitle('Explore');
   const navigate = useNavigate();
   const { status } = useAuth();
+  const { active: onboardingActive, currentStep: onboardingStep } = useOnboarding();
   const accountLogin = status?.account?.login ?? '';
   const [search, setSearch] = useState(accountLogin);
   const [validationError, setValidationError] = useState('');
@@ -59,6 +61,13 @@ export function ExploreStartPage() {
           <Heading id="search-title" size="h2">Open a public profile</Heading>
           <Text size="sm" color="$mutedForeground">Handles and full github.com profile URLs both work.</Text>
         </div>
+        {onboardingActive && onboardingStep === 'trailhead' ? (
+          <div className="onboarding-context onboarding-start-context" role="status">
+            <Text size="xs" color="$mutedForeground">Step 1 of 3</Text>
+            <Heading size="h3">Choose your trailhead</Heading>
+            <Text size="sm" color="$mutedForeground">Your connected account is ready below, or enter any public GitHub profile to begin.</Text>
+          </div>
+        ) : null}
         <form className="profile-search" onSubmit={submit} noValidate>
           <SearchField
             label="GitHub username"

--- a/apps/web/src/pages/RepositoryPage.tsx
+++ b/apps/web/src/pages/RepositoryPage.tsx
@@ -8,6 +8,7 @@ import { api } from '../api';
 import { GraphTrail } from '../components/GraphTrail';
 import { buildExploreHref, normalizeConnectionDirection, parseTrail, type ConnectionDirection } from '../lib/graph-navigation';
 import { cacheLabel, compactNumber, formatTimestamp } from '../lib/format';
+import { useOnboarding } from '../onboarding';
 import { useDocumentTitle } from '../useDocumentTitle';
 
 const ownerPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/;
@@ -17,6 +18,7 @@ export function RepositoryPage() {
   const { owner = '', repo = '' } = useParams();
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
+  const { refreshProgress } = useOnboarding();
   const fullName = `${owner}/${repo}`;
   const valid = ownerPattern.test(owner) && repositoryPattern.test(repo);
   const trail = useMemo(() => parseTrail(searchParams.get('trail')), [searchParams]);
@@ -46,6 +48,7 @@ export function RepositoryPage() {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['bookmarks'] }),
         queryClient.invalidateQueries({ queryKey: ['user-neighborhood'] }),
+        refreshProgress(),
       ]);
     },
     retry: false,

--- a/apps/web/src/pages/SavedPage.tsx
+++ b/apps/web/src/pages/SavedPage.tsx
@@ -7,6 +7,7 @@ import { ArrowRightIcon, BookmarkIcon, CircleAlertIcon, FolderIcon, HistoryIcon,
 
 import { api } from '../api';
 import { bookmarkKind, describeBookmarkTarget, formatTimestamp, seedLabel, snapshotSummary } from '../lib/format';
+import { useOnboarding } from '../onboarding';
 import { buildExploreHref, isLikelyGitHubLogin, normalizeLoginInput } from '../lib/graph-navigation';
 import { useDocumentTitle } from '../useDocumentTitle';
 
@@ -65,6 +66,7 @@ export function SavedPage() {
 
 function BookmarksView() {
   const queryClient = useQueryClient();
+  const { refreshProgress } = useOnboarding();
   const [search, setSearch] = useState('');
   const [targetKind, setTargetKind] = useState<'repository' | 'user'>('repository');
   const [targetValue, setTargetValue] = useState('');
@@ -89,6 +91,7 @@ function BookmarksView() {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['bookmarks'] }),
         queryClient.invalidateQueries({ queryKey: ['user-neighborhood'] }),
+        refreshProgress(),
       ]);
     },
     retry: false,

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,11 +1,12 @@
 import type { DiscoveryWarmup, DiscoveryWarmupStatus } from '@gitexplore/api-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Alert, Avatar, Badge, Button, Heading, Progress, Skeleton, Text } from 'strawn';
-import { CircleAlertIcon, ClockIcon, DatabaseIcon, LogOutIcon, RefreshIcon } from 'strawn-icons';
+import { CircleAlertIcon, ClockIcon, DatabaseIcon, LogOutIcon, MapPinIcon, RefreshIcon } from 'strawn-icons';
 
 import { api } from '../api';
 import { useAuth, useLogout } from '../auth';
 import { formatTimestamp } from '../lib/format';
+import { useOnboarding } from '../onboarding';
 import { useDocumentTitle } from '../useDocumentTitle';
 
 const activeWarmupStatuses: DiscoveryWarmupStatus[] = ['QUEUED', 'RUNNING'];
@@ -67,6 +68,7 @@ export function SettingsPage() {
   const { status } = useAuth();
   const logout = useLogout();
   const queryClient = useQueryClient();
+  const { progress: onboarding, restart, restartPending, error: onboardingError } = useOnboarding();
 
   const warmupQuery = useQuery({
     queryKey: ['discovery-warmup'],
@@ -229,6 +231,27 @@ export function SettingsPage() {
             </Alert>
           ) : null}
         </div>
+      </section>
+
+      <section className="settings-section" aria-labelledby="onboarding-settings-title">
+        <div className="settings-heading">
+          <span className="settings-index">04</span>
+          <div>
+            <Heading id="onboarding-settings-title" size="h2">First-value guide</Heading>
+            <Text size="sm" color="$mutedForeground">Replay the three-step trail through a person, a connection, and a private repository save.</Text>
+          </div>
+        </div>
+        <div className="onboarding-settings-row">
+          <span><MapPinIcon aria-hidden="true" size={20} /><span><strong>{onboarding?.status === 'COMPLETED' ? 'Onboarding complete' : onboarding?.status === 'DISMISSED' ? 'Onboarding skipped' : 'Onboarding available'}</strong><small>Restarting creates a fresh activation window without changing saved data.</small></span></span>
+          <Button
+            variant="outline"
+            loading={restartPending}
+            onClick={() => void restart().then(() => window.location.assign('/app/explore'))}
+          >
+            Replay onboarding
+          </Button>
+        </div>
+        {onboardingError ? <Alert tone="warning" title="Onboarding could not be updated">{onboardingError.message}</Alert> : null}
       </section>
 
     </div>

--- a/apps/web/src/pages/UserExplorerPage.tsx
+++ b/apps/web/src/pages/UserExplorerPage.tsx
@@ -13,6 +13,7 @@ import { RepositoryCandidateCard } from '../components/RepositoryCandidateCard';
 import { UserInsights } from '../components/UserInsights';
 import { isLikelyGitHubLogin, normalizeConnectionDirection, normalizeLoginInput, normalizeTrail, setConnectionDirection } from '../lib/graph-navigation';
 import { cacheLabel, compactNumber } from '../lib/format';
+import { useOnboarding } from '../onboarding';
 import { useDocumentTitle } from '../useDocumentTitle';
 
 const neighborhoodLimit = 36;
@@ -68,6 +69,7 @@ export function UserExplorerPage() {
   const { login: rawLogin = '' } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
+  const { active: onboardingActive, currentStep: onboardingStep, refreshProgress } = useOnboarding();
   const attemptedAutoExpansions = useRef(new Set<string>());
   const attemptedVisitKeys = useRef(new Set<string>());
   const [visibleRepositories, setVisibleRepositories] = useState(8);
@@ -140,6 +142,7 @@ export function UserExplorerPage() {
         ...current,
         [variables.visitKey]: { status: 'success' },
       }));
+      void refreshProgress();
     },
     onError: (error, variables) => {
       setVisitWrites((current) => ({
@@ -245,6 +248,7 @@ export function UserExplorerPage() {
         repositories: current.repositories.map((candidate) => candidate.repository.fullName === fullName ? { ...candidate, saved: true } : candidate),
       }) : current);
       void queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
+      void refreshProgress();
     },
   });
 
@@ -470,7 +474,14 @@ export function UserExplorerPage() {
       )}
 
       <div className="atlas-grid">
-        <aside className="connection-panel" aria-label="Connections">
+        <aside id="connections" className="connection-panel onboarding-focus-target" aria-label="Connections" tabIndex={-1}>
+          {onboardingActive && onboardingStep === 'connection' ? (
+            <div className="onboarding-context" role="status">
+              <Text size="xs" color="$mutedForeground">Step 2 of 3</Text>
+              <Heading size="h3">Follow a human signal</Heading>
+              <Text size="sm" color="$mutedForeground">Choose any follower or following account. Your trail stays visible as you move.</Text>
+            </div>
+          ) : null}
           <Tabs
             label="Connection direction"
             value={direction}
@@ -516,7 +527,7 @@ export function UserExplorerPage() {
             )}
           </div>
 
-          <section className="discoveries" aria-labelledby="discoveries-title">
+          <section id="discoveries" className="discoveries onboarding-focus-target" aria-labelledby="discoveries-title" tabIndex={-1}>
             <div className="section-heading-row discoveries-heading">
               <div>
                 <Text size="xs" color="$mutedForeground">Ranked discoveries</Text>
@@ -525,6 +536,13 @@ export function UserExplorerPage() {
               </div>
               <Badge tone="neutral" leadingIcon={<UsersIcon aria-hidden="true" size={14} />}>{neighborhood.repositories.length} found</Badge>
             </div>
+            {onboardingActive && onboardingStep === 'repository' ? (
+              <div className="onboarding-context" role="status">
+                <Text size="xs" color="$mutedForeground">Step 3 of 3</Text>
+                <Heading size="h3">Keep one promising find</Heading>
+                <Text size="sm" color="$mutedForeground">Save any ranked repository below. It goes to your private field notebook in one click.</Text>
+              </div>
+            ) : null}
             {displayedRepositories.length ? (
               <div className="repository-results">
                 {displayedRepositories.map((candidate, index) => (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -206,8 +206,244 @@ a {
 }
 
 .app-main {
+  display: grid;
+  align-content: start;
+  gap: var(--space-6);
   width: min(100%, var(--size-container-wide));
   padding: var(--space-8) clamp(var(--space-5), 4vw, var(--space-12)) var(--space-16);
+}
+
+/* First-value onboarding */
+.onboarding-skeleton,
+.onboarding-card,
+.onboarding-collapsed {
+  width: 100%;
+}
+
+.onboarding-card {
+  position: relative;
+  display: grid;
+  gap: var(--space-5);
+  overflow: hidden;
+  border: var(--border-weight-subtle) solid var(--border);
+  border-top: var(--border-weight-strong) solid var(--primary);
+}
+
+.onboarding-card::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 9rem;
+  height: 9rem;
+  border-radius: 999px;
+  background: var(--secondary);
+  content: '';
+  opacity: 0.55;
+  pointer-events: none;
+  transform: translate(42%, -58%);
+}
+
+.onboarding-header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: var(--space-5);
+}
+
+.onboarding-header > div {
+  display: grid;
+  max-width: 48rem;
+  gap: var(--space-2);
+}
+
+.onboarding-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.onboarding-steps li {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  grid-template-columns: 2rem minmax(0, 1fr);
+  align-items: start;
+  gap: var(--space-3);
+  padding-right: var(--space-5);
+}
+
+.onboarding-steps li:not(:last-child)::after {
+  position: absolute;
+  z-index: 0;
+  top: 1rem;
+  right: 0;
+  left: 2rem;
+  height: var(--border-weight-subtle);
+  background: var(--border-strong);
+  content: '';
+}
+
+.onboarding-step-marker {
+  z-index: 1;
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border: var(--border-weight-subtle) solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: var(--type-size-xs);
+}
+
+.onboarding-steps li.current .onboarding-step-marker {
+  border-color: var(--primary);
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+
+.onboarding-steps li.complete .onboarding-step-marker {
+  border-color: var(--success);
+  background: var(--success);
+  color: var(--success-foreground);
+}
+
+.onboarding-steps li > span:last-child {
+  z-index: 1;
+  display: grid;
+  gap: var(--space-1);
+  background: var(--surface);
+}
+
+.onboarding-steps small,
+.onboarding-settings-row small {
+  color: var(--muted-foreground);
+  font-size: var(--type-size-xs);
+  line-height: var(--type-leading-normal);
+}
+
+.onboarding-controls,
+.onboarding-mapping-action,
+.onboarding-completion-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.onboarding-action {
+  min-height: var(--control-hit-target);
+}
+
+.onboarding-mapping {
+  display: grid;
+  gap: var(--space-3);
+  border-top: var(--border-weight-subtle) solid var(--border);
+  padding-top: var(--space-4);
+}
+
+.onboarding-mapping-copy,
+.onboarding-mapping-progress > div:first-child {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.onboarding-mapping-copy {
+  justify-content: flex-start;
+}
+
+.onboarding-mapping-copy > div,
+.onboarding-mapping-progress {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.onboarding-mapping-icon {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+
+.onboarding-mapping-action {
+  justify-content: space-between;
+}
+
+.onboarding-collapsed {
+  display: grid;
+  min-height: var(--control-hit-target);
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  border: var(--border-weight-subtle) solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  padding: var(--space-3) var(--space-4);
+  color: var(--foreground);
+  text-align: left;
+}
+
+.onboarding-collapsed > span {
+  display: grid;
+}
+
+.onboarding-collapsed small {
+  color: var(--muted-foreground);
+}
+
+.onboarding-context {
+  display: grid;
+  gap: var(--space-2);
+  border-left: var(--border-weight-strong) solid var(--primary);
+  background: var(--secondary);
+  padding: var(--space-4);
+}
+
+.onboarding-context h3 {
+  font-size: var(--type-size-lg);
+}
+
+.onboarding-start-context {
+  grid-column: 1 / -1;
+  grid-row: 2;
+}
+
+.onboarding-focus-target {
+  scroll-margin-top: var(--space-6);
+}
+
+.onboarding-focus-target:focus-visible {
+  outline: var(--border-weight-strong) solid var(--ring);
+  outline-offset: var(--space-2);
+}
+
+.onboarding-settings-row,
+.onboarding-settings-row > span,
+.onboarding-settings-row > span > span {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.onboarding-settings-row {
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.onboarding-settings-row > span > span {
+  display: grid;
+  gap: var(--space-1);
 }
 
 .page-stack {
@@ -628,45 +864,42 @@ a {
 }
 
 .graph-trail {
-  position: relative;
   display: flex;
+  width: max-content;
+  min-width: 0;
+  max-width: 100%;
   min-height: var(--control-hit-target);
   align-items: center;
-  gap: var(--space-3);
-  overflow-x: auto;
-  border-bottom: var(--border-weight-subtle) solid var(--border);
-  padding: 0 0 var(--space-3) var(--space-6);
+  justify-self: start;
+  gap: var(--space-2);
+  overflow: hidden;
+  border: var(--border-weight-subtle) solid color-mix(in srgb, var(--primary) 18%, var(--border));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary) 4%, var(--surface));
+  padding-inline: var(--space-3);
   scrollbar-width: thin;
 }
 
 .trail-origin {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  width: var(--space-3);
-  height: var(--space-3);
-  border: var(--border-weight-strong) solid var(--accent-foreground);
+  width: var(--space-2);
+  height: var(--space-2);
+  flex: 0 0 auto;
+  border: var(--border-weight-subtle) solid var(--primary);
   border-radius: var(--radius-pill);
-  background: var(--accent);
-}
-
-.graph-trail::before {
-  position: absolute;
-  bottom: calc(var(--space-2) - var(--border-weight-subtle));
-  left: var(--space-2);
-  width: var(--space-4);
-  height: var(--border-weight-strong);
-  background: var(--accent-foreground);
-  content: '';
+  background: color-mix(in srgb, var(--primary) 14%, var(--surface));
 }
 
 .graph-trail ol {
   display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
   align-items: center;
-  gap: var(--space-1);
+  gap: 0;
+  overflow-x: auto;
   margin: 0;
   padding: 0;
   list-style: none;
+  scrollbar-width: thin;
   white-space: nowrap;
 }
 
@@ -686,20 +919,26 @@ a {
   align-items: center;
   justify-content: center;
   color: var(--muted-foreground);
+  padding-inline: var(--space-1);
   text-underline-offset: var(--space-1);
 }
 
 .graph-trail [aria-current='page'] {
+  display: inline-flex;
+  min-height: var(--control-hit-target);
+  align-items: center;
   color: var(--accent-foreground);
   font-weight: var(--type-weight-semibold);
+  padding-inline: var(--space-1);
 }
 
 .trail-depth {
   flex: 0 0 auto;
-  margin-left: auto;
+  border-left: var(--border-weight-subtle) solid var(--border);
   color: var(--muted-foreground);
   font-family: var(--font-mono);
   font-size: var(--type-size-xs);
+  padding-left: var(--space-3);
   white-space: nowrap;
 }
 
@@ -1700,6 +1939,55 @@ a {
     padding-block: var(--space-6);
   }
 
+  .onboarding-card {
+    padding: var(--space-5);
+  }
+
+  .onboarding-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .onboarding-header > button {
+    align-self: start;
+  }
+
+  .onboarding-steps {
+    grid-template-columns: 1fr;
+    gap: var(--space-3);
+  }
+
+  .onboarding-steps li {
+    min-height: var(--control-hit-target);
+    padding-right: 0;
+  }
+
+  .onboarding-steps li:not(:last-child)::after {
+    top: 2rem;
+    bottom: calc(var(--space-3) * -1);
+    left: 1rem;
+    width: var(--border-weight-subtle);
+    height: auto;
+  }
+
+  .onboarding-controls,
+  .onboarding-mapping-action {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .onboarding-action,
+  .onboarding-controls > button,
+  .onboarding-mapping-action > button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .onboarding-settings-row,
+  .onboarding-settings-row > button {
+    width: 100%;
+  }
+
   .login-connect {
     order: -1;
   }
@@ -1852,6 +2140,10 @@ a {
     padding-inline: var(--space-4);
   }
 
+  .graph-trail {
+    width: 100%;
+  }
+
   .node-person {
     align-items: center;
   }
@@ -1947,7 +2239,7 @@ a {
 @media (forced-colors: active) {
   .nav-link.active::before,
   .login-thread,
-  .graph-trail::before,
+  .trail-origin,
   .repo-connector {
     background: Highlight;
   }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -17,5 +17,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    exclude: ['e2e/**', '**/node_modules/**'],
   },
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,5 +8,6 @@ This folder is the source of truth for how GitExplore is structured and how to r
 - [Docker runtime and boot flow](runtime.md)
 - [Production deployment scaffold](deployment.md)
 - [UI login flow](ui-login-flow.md)
+- [First-value onboarding](first-value-onboarding.md)
 
 Start with the graph-explorer document for the implemented product workflow and API. Architecture and data-model documents define the shared public graph/private user overlay; runtime and login documents cover local deployment and session creation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ flowchart LR
     rest --> web
 ```
 
-Public GitHub identities, public repositories, and relationship facts are shared cache data. The authenticated app user owns connection credentials, the opaque browser session, bookmark state, categories, snapshots, sync state, recent-person routes, expedition progress, and discovery-warmup progress. Repository discovery joins the shared facts to only the current user's save overlay. Browser connections are canonicalized by stable GitHub user id, so reconnecting the same GitHub account preserves that private overlay. The stable account link remains when credentials are disconnected.
+Public GitHub identities, public repositories, and relationship facts are shared cache data. The authenticated app user owns connection credentials, the opaque browser session, bookmark state, categories, snapshots, sync state, recent-person routes, expedition progress, versioned onboarding lifecycle state, and discovery-warmup progress. Repository discovery joins the shared facts to only the current user's save overlay. Browser connections are canonicalized by stable GitHub user id, so reconnecting the same GitHub account preserves that private overlay. The stable account link remains when credentials are disconnected.
 
 Shared graph identity is also stable-id first. Lowercase `login_key` and `full_name_key` properties provide case-insensitive alias lookup, while GitHub's numeric user/repository ids remain canonical. A rename moves the existing stable node to its new alias; reuse of an old alias by a different numeric id does not merge the two histories.
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -105,7 +105,7 @@ The shared graph does not use `LocalUser-[:OWNS_GRAPH]->User`. Public facts are 
 
 ```mermaid
 flowchart LR
-    local["LocalUser {id, exploration_max_depth}"]
+    local["LocalUser {id, exploration_max_depth,\nonboarding version/status/timestamps}"]
     category["Category {user_id, name}"]
     bookmark["Bookmark {id, user_id, target_kind,\ntarget_github_id, note, created_at}"]
     snapshot["ExplorationSnapshot {id, user_id, ...}"]
@@ -129,6 +129,8 @@ flowchart LR
 ```
 
 Recent-person history is a private relationship from `LocalUser` to the canonical shared `User`, so GitHub login renames keep the saved destination attached to its stable numeric identity. The relationship stores the latest bounded trail (at most eight stable GitHub user ids with canonical login fallbacks), connection direction, server timestamp, visit count, and explicit visibility. Before a route can increase progress, every hop must resolve in the shared graph and every adjacent pair must have a `FOLLOWS` relationship in either direction. Recording a visit preserves `visible = false` after the user removes that person; the profile's Add action is the only operation that makes it visible again. Writes retain the 50 most recently viewed visible relationships plus 50 hidden opt-out tombstones, so an older explicit removal cannot silently reappear after pruning. `LocalUser.exploration_max_depth` only increases and is independent of removal, so earned Trailhead/Scout/Pathfinder/Cartographer progress survives restarts and shallower routes. The file adapter stores the equivalent per-user records and maximum in `graph.json`.
+
+`LocalUser` also owns the versioned onboarding lifecycle. Neo4j stores `onboarding_version`, `onboarding_status`, `onboarding_started_at`, `onboarding_completed_at`, and `onboarding_dismissed_at`; file mode stores the equivalent record in a serde-defaulted per-user map. Step completion is derived from private visits and repository bookmarks within the active start window, not persisted as client-controlled booleans. Missing or older-version state means the current guide has not started.
 
 `SyncState` is keyed directly by `user_id`; the current adapter does not add a relationship from `LocalUser`. It also owns that app user's serialized discovery-warmup job and a separately queryable status. The private job contains its id, connected-account seed, deduplicated expanded/frontier logins, current login, reserve observation, timestamps, and bounded error. Expanded and pending logins share a 10,000-user total bound, chosen to keep one private job well below the 190,000-node production import boundary. Once that bound is reached, additional candidates set `frontierTruncated` and are not retained, so exhausting the retained frontier still terminates the job. Neo4j updates this state only while the caller owns the fenced `discovery-warmup:<user_id>` `RefreshLease`; public users, repositories, and relationships discovered by the job still enter the shared graph.
 

--- a/docs/first-value-onboarding.md
+++ b/docs/first-value-onboarding.md
@@ -1,0 +1,48 @@
+# First-value onboarding
+
+GitExplore presents a versioned, non-blocking guide to every authenticated account that has no terminal record for the current onboarding version. Version 1 teaches the product through real data: open a GitHub profile, follow one valid graph connection, and save one repository to the private overlay.
+
+The guide is rendered inside the authenticated app shell, so OAuth return paths and direct links remain intact. It can be collapsed, dismissed, or replayed from Settings. Completion and dismissal persist with the canonical app user and therefore survive browser changes and GitHub reconnection.
+
+## Progress rules
+
+The server does not accept client-authored step flags. For the current onboarding `started_at` window it derives:
+
+- `openedTrailhead` from a successfully recorded person visit
+- `followedConnection` from a recorded trail containing at least two people
+- `savedRepository` from a repository bookmark created after the window began
+- `mappingStarted` from the presence of a private discovery-warmup job; this is informational and never required
+
+Completing onboarding validates the three required facts again. Replay creates a new start timestamp, so actions from an older run do not complete the new run.
+
+## Persistence
+
+File mode stores a serde-defaulted per-user onboarding map in `graph.json`. Neo4j stores version, status, and lifecycle timestamps on the private `LocalUser` node. Missing or older-version state resolves to `NOT_STARTED`; no client operation accepts an app-user id.
+
+## Browser behavior
+
+The app begins lifecycle tracking when the version-one guide first appears. It does not start discovery mapping automatically. The optional mapping action explains the protected 1,000-request reserve and invokes the existing idempotent warmup mutation only after explicit user input. Mapping failures and reserve-protected states do not block the three-step activation path.
+
+The UI invalidates onboarding progress after successful visit and repository-save operations. Once all required facts are present, it completes the lifecycle and shows a session-level success message with links to Saved and continued exploration.
+
+## GraphQL operations
+
+All operations use the server-managed browser session:
+
+```graphql
+query OnboardingProgress {
+  onboardingProgress {
+    version
+    status
+    startedAt
+    completedAt
+    dismissedAt
+    openedTrailhead
+    followedConnection
+    savedRepository
+    mappingStarted
+  }
+}
+```
+
+The mutations are `beginOnboarding`, `dismissOnboarding`, `restartOnboarding`, and `completeOnboarding`. Each returns the same progress object. Begin and complete are idempotent; complete returns `BAD_USER_INPUT` until all required actions have succeeded.

--- a/docs/graph-explorer.md
+++ b/docs/graph-explorer.md
@@ -206,6 +206,12 @@ mutation HideRecentPerson {
 }
 ```
 
+### First-value onboarding
+
+`onboardingProgress` returns the current session owner's versioned lifecycle and derives its three required steps from private activity after `startedAt`. The lifecycle mutations accept no identity argument: `beginOnboarding`, `dismissOnboarding`, `restartOnboarding`, and `completeOnboarding`. Completion validates a recorded trailhead visit, a route with at least one connection, and a repository bookmark in the active window. See [First-value onboarding](first-value-onboarding.md) for the browser behavior and full operation shape.
+
+Discovery warmup is reported as optional `mappingStarted` context. Reading or beginning onboarding never starts mapping or spends GitHub requests.
+
 ### Warm the discovery graph
 
 `startDiscoveryWarmup` starts one private job for the authenticated app user; it accepts no identity or seed argument. The connected GitHub login is the seed. Repeated starts return the same active job, so browser retries cannot create duplicate work. `COMPLETED` remains idempotently complete. A `RESERVE_PROTECTED` job is also returned unchanged before its recorded reset; an explicit start after that reset atomically requeues the same job id with its existing frontier and progress. A start after `FAILED` creates a new attempt.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -81,6 +81,8 @@ After browser OAuth, use `http://localhost:3000/app/explore` for the GraphQL exp
 
 The session cookie and its durable Neo4j record expire after 30 days. Neo4j stores a keyed digest rather than the cookie value. Expired records are purged during session creation/resolution, and the store is bounded to 4,096 active sessions. `POST /auth/logout` removes the current server mapping and returns an expired session cookie. Browser sign-out does not disconnect the GitHub credential. A credential disconnect removes encrypted credential properties but retains the stable account link so reconnecting the same GitHub account recovers its private overlay.
 
+The authenticated shell also reads private `onboardingProgress`. Accounts without the current version see the embedded three-step first-value guide; lifecycle reads and writes are cookie-derived and accept no user id. The guide never starts discovery warmup automatically. Its optional mapping control invokes `startDiscoveryWarmup` only after explicit input and preserves the existing 1,000-request reserve.
+
 ### One-time identity migration
 
 For a stack with an existing `/var/lib/gitexplore/identity.json`, stop the old `gitexplore` writer, start Neo4j and apply the current schema, then run the guarded migration with the same data volume and the production identity key:

--- a/docs/ui-login-flow.md
+++ b/docs/ui-login-flow.md
@@ -75,6 +75,8 @@ The React auth boundary waits for the status query before resolving `/app`. If t
 
 Browser requests target the page origin and use `credentials: "include"`. During development, Vite proxies API paths to the Rust service; Docker Compose sets the server-only proxy target to `http://gitexplore:4000`. In production, Vercel routes those same paths to the Rust service under the single GitExplore origin. All frontend data loading happens in the browser, with no browser-exposed API-origin setting.
 
+Once the shell is available it reads `onboardingProgress`. Missing version-one state opens the embedded first-value guide without changing the OAuth return path or current route. The guide begins only lifecycle timing; GitHub discovery warmup remains an explicit optional action. Completion, dismissal, and replay are stored on the canonical private app-user overlay.
+
 ### 5. Sign out
 
 The application shell calls:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "production:smoke": "node .github/scripts/verify-live-frontend.mjs"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.12.1",
     "@emnapi/core": "1.11.1",
     "@emnapi/runtime": "1.11.1",
     "@playwright/test": "1.61.1",

--- a/packages/api_client/src/index.test.ts
+++ b/packages/api_client/src/index.test.ts
@@ -231,6 +231,50 @@ describe('createGitExploreApi', () => {
     expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ credentials: 'include' });
   });
 
+  it('reads and transitions cookie-authenticated onboarding without a user id', async () => {
+    const fetchMock = vi.fn(async (_input: URL | RequestInfo, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        query: string;
+        variables: Record<string, unknown>;
+      };
+      expect(body.variables).toEqual({});
+      expect(body.query).not.toContain('userId');
+      const progress = {
+        version: 1,
+        status: body.query.includes('DismissOnboarding') ? 'DISMISSED' : 'IN_PROGRESS',
+        startedAt: '2026-08-01T10:00:00Z',
+        completedAt: null,
+        dismissedAt: body.query.includes('DismissOnboarding') ? '2026-08-01T10:05:00Z' : null,
+        openedTrailhead: false,
+        followedConnection: false,
+        savedRepository: false,
+        mappingStarted: false
+      };
+      const key = body.query.includes('BeginOnboarding')
+        ? 'beginOnboarding'
+        : body.query.includes('DismissOnboarding')
+          ? 'dismissOnboarding'
+          : body.query.includes('RestartOnboarding')
+            ? 'restartOnboarding'
+            : body.query.includes('CompleteOnboarding')
+              ? 'completeOnboarding'
+              : 'onboardingProgress';
+      return Response.json({ data: { [key]: progress } });
+    });
+    const api = createGitExploreApi({
+      baseUrl: 'http://localhost:4000',
+      fetch: fetchMock as typeof fetch
+    });
+
+    await expect(api.getOnboardingProgress()).resolves.toMatchObject({ version: 1 });
+    await expect(api.beginOnboarding()).resolves.toMatchObject({ status: 'IN_PROGRESS' });
+    await expect(api.dismissOnboarding()).resolves.toMatchObject({ status: 'DISMISSED' });
+    await expect(api.restartOnboarding()).resolves.toMatchObject({ status: 'IN_PROGRESS' });
+    await expect(api.completeOnboarding()).resolves.toMatchObject({ version: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ credentials: 'include' });
+  });
+
   it('persists recent people with their hop trail and normalizes direction', async () => {
     const fetchMock = vi.fn(async (_input: URL | RequestInfo, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body)) as {

--- a/packages/api_client/src/index.ts
+++ b/packages/api_client/src/index.ts
@@ -189,6 +189,24 @@ export type DiscoveryWarmup = {
   lastError: string | null;
 };
 
+export type OnboardingStatus =
+  | 'NOT_STARTED'
+  | 'IN_PROGRESS'
+  | 'COMPLETED'
+  | 'DISMISSED';
+
+export type OnboardingProgress = {
+  version: number;
+  status: OnboardingStatus;
+  startedAt: string | null;
+  completedAt: string | null;
+  dismissedAt: string | null;
+  openedTrailhead: boolean;
+  followedConnection: boolean;
+  savedRepository: boolean;
+  mappingStarted: boolean;
+};
+
 export type RepositoryContributor = {
   githubId: string;
   login: string;
@@ -319,6 +337,10 @@ export class GitExploreApiError extends Error {
 export function createGitExploreApi(options: ApiClientOptions) {
   const baseUrl = options.baseUrl.replace(/\/$/, '');
   const fetchImpl = options.fetch ?? fetch;
+  const onboardingFields = `
+    version status startedAt completedAt dismissedAt
+    openedTrailhead followedConnection savedRepository mappingStarted
+  `;
 
   async function request<T>(
     path: string,
@@ -477,6 +499,51 @@ export function createGitExploreApi(options: ApiClientOptions) {
         {}
       );
       return data.startDiscoveryWarmup;
+    },
+    getOnboardingProgress: async () => {
+      const data = await graphql<{ onboardingProgress: OnboardingProgress }>(
+        `query OnboardingProgress {
+          onboardingProgress { ${onboardingFields} }
+        }`,
+        {}
+      );
+      return data.onboardingProgress;
+    },
+    beginOnboarding: async () => {
+      const data = await graphql<{ beginOnboarding: OnboardingProgress }>(
+        `mutation BeginOnboarding {
+          beginOnboarding { ${onboardingFields} }
+        }`,
+        {}
+      );
+      return data.beginOnboarding;
+    },
+    dismissOnboarding: async () => {
+      const data = await graphql<{ dismissOnboarding: OnboardingProgress }>(
+        `mutation DismissOnboarding {
+          dismissOnboarding { ${onboardingFields} }
+        }`,
+        {}
+      );
+      return data.dismissOnboarding;
+    },
+    restartOnboarding: async () => {
+      const data = await graphql<{ restartOnboarding: OnboardingProgress }>(
+        `mutation RestartOnboarding {
+          restartOnboarding { ${onboardingFields} }
+        }`,
+        {}
+      );
+      return data.restartOnboarding;
+    },
+    completeOnboarding: async () => {
+      const data = await graphql<{ completeOnboarding: OnboardingProgress }>(
+        `mutation CompleteOnboarding {
+          completeOnboarding { ${onboardingFields} }
+        }`,
+        {}
+      );
+      return data.completeOnboarding;
     },
     getRepositoryInsights: async (fullName: string, limit = 12) => {
       const data = await graphql<{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
 
   .:
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.12.1
+        version: 4.12.1(playwright-core@1.61.1)
       '@emnapi/core':
         specifier: 1.11.1
         version: 1.11.1
@@ -114,6 +117,11 @@ packages:
   '@asamuzakjp/dom-selector@8.3.0':
     resolution: {integrity: sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==}
     engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -2227,6 +2235,10 @@ packages:
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
 
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
     peerDependencies:
@@ -3574,6 +3586,11 @@ snapshots:
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
+
+  '@axe-core/playwright@4.12.1(playwright-core@1.61.1)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.61.1
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -5367,6 +5384,8 @@ snapshots:
       retry: 0.13.1
 
   async-sema@3.1.1: {}
+
+  axe-core@4.12.1: {}
 
   b4a@1.8.1: {}
 

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -45,6 +45,7 @@ use crate::{
         USER_COMMIT_ACTIVITY_WINDOW_DAYS, UserCommitRepositoriesSnapshot, UserCommitRepository,
         UserCommitRepositoryInsights, refresh_is_active,
     },
+    onboarding::{OnboardingRecord, OnboardingStatus},
     ports::{
         BookmarkRepository, CategoryRepository, DeviceLoginStart, DiscoveryRepository,
         ExplorationRepository, GitHubAuthConfig, GitHubClientPort, GitHubImportRepository,
@@ -608,6 +609,8 @@ struct GraphStore {
     sync_status: HashMap<String, SyncStatus>,
     #[serde(default)]
     discovery_warmups: HashMap<String, DiscoveryWarmupJob>,
+    #[serde(default)]
+    onboarding: HashMap<String, OnboardingRecord>,
     shared: SharedGraphStore,
     categories: HashMap<String, Vec<Category>>,
     bookmarks: HashMap<String, Vec<Bookmark>>,
@@ -1537,6 +1540,20 @@ impl SyncStateRepository for LocalSyncStateRepository {
         guard.discovery_warmups.insert(user_id.to_string(), warmup);
         self.store.persist(&guard)?;
         Ok(true)
+    }
+
+    async fn onboarding_record(&self, user_id: &str) -> AppResult<Option<OnboardingRecord>> {
+        Ok(self.store.lock()?.onboarding.get(user_id).cloned())
+    }
+
+    async fn save_onboarding_record(
+        &self,
+        user_id: &str,
+        record: OnboardingRecord,
+    ) -> AppResult<()> {
+        let mut guard = self.store.lock()?;
+        guard.onboarding.insert(user_id.to_string(), record);
+        self.store.persist(&guard)
     }
 }
 
@@ -5268,6 +5285,120 @@ impl SyncStateRepository for Neo4jSyncStateRepository {
             return Ok(false);
         };
         row.get::<bool>("updated").map_err(map_neo4j_decode)
+    }
+
+    async fn onboarding_record(&self, user_id: &str) -> AppResult<Option<OnboardingRecord>> {
+        let mut rows = self
+            .client
+            .graph
+            .execute_on(
+                &self.client.database,
+                query(
+                    "MATCH (local:LocalUser {id: $user_id})
+                     WHERE local.onboarding_version IS NOT NULL
+                     RETURN local.onboarding_version AS version,
+                            local.onboarding_status AS status,
+                            toString(local.onboarding_started_at) AS started_at,
+                            toString(local.onboarding_completed_at) AS completed_at,
+                            toString(local.onboarding_dismissed_at) AS dismissed_at
+                     LIMIT 1",
+                )
+                .param("user_id", user_id.to_string()),
+            )
+            .await
+            .map_err(|error| AppError::External(error.to_string()))?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| AppError::External(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+        let version = row.get::<i64>("version").map_err(map_neo4j_decode)?;
+        let version = i32::try_from(version)
+            .map_err(|_| AppError::Storage("onboarding version is out of range".to_string()))?;
+        let status =
+            parse_onboarding_status(&row.get::<String>("status").map_err(map_neo4j_decode)?)?;
+        let started_at = row
+            .get::<Option<String>>("started_at")
+            .map_err(map_neo4j_decode)?
+            .and_then(|value| parse_timestamp(&value));
+        let completed_at = row
+            .get::<Option<String>>("completed_at")
+            .map_err(map_neo4j_decode)?
+            .and_then(|value| parse_timestamp(&value));
+        let dismissed_at = row
+            .get::<Option<String>>("dismissed_at")
+            .map_err(map_neo4j_decode)?
+            .and_then(|value| parse_timestamp(&value));
+        Ok(Some(OnboardingRecord {
+            version,
+            status,
+            started_at,
+            completed_at,
+            dismissed_at,
+        }))
+    }
+
+    async fn save_onboarding_record(
+        &self,
+        user_id: &str,
+        record: OnboardingRecord,
+    ) -> AppResult<()> {
+        self.client
+            .run(
+                query(
+                    "MERGE (local:LocalUser {id: $user_id})
+                     SET local.onboarding_version = $version,
+                         local.onboarding_status = $status,
+                         local.onboarding_started_at = CASE
+                           WHEN $started_at = '' THEN null ELSE datetime($started_at)
+                         END,
+                         local.onboarding_completed_at = CASE
+                           WHEN $completed_at = '' THEN null ELSE datetime($completed_at)
+                         END,
+                         local.onboarding_dismissed_at = CASE
+                           WHEN $dismissed_at = '' THEN null ELSE datetime($dismissed_at)
+                         END",
+                )
+                .param("user_id", user_id.to_string())
+                .param("version", i64::from(record.version))
+                .param("status", record.status.as_str().to_string())
+                .param(
+                    "started_at",
+                    record
+                        .started_at
+                        .map(|value| value.to_rfc3339())
+                        .unwrap_or_default(),
+                )
+                .param(
+                    "completed_at",
+                    record
+                        .completed_at
+                        .map(|value| value.to_rfc3339())
+                        .unwrap_or_default(),
+                )
+                .param(
+                    "dismissed_at",
+                    record
+                        .dismissed_at
+                        .map(|value| value.to_rfc3339())
+                        .unwrap_or_default(),
+                ),
+            )
+            .await
+    }
+}
+
+fn parse_onboarding_status(value: &str) -> AppResult<OnboardingStatus> {
+    match value {
+        "not_started" => Ok(OnboardingStatus::NotStarted),
+        "in_progress" => Ok(OnboardingStatus::InProgress),
+        "completed" => Ok(OnboardingStatus::Completed),
+        "dismissed" => Ok(OnboardingStatus::Dismissed),
+        _ => Err(AppError::Storage(format!(
+            "stored onboarding status `{value}` is invalid"
+        ))),
     }
 }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -32,11 +32,14 @@ use crate::{
         PendingBrowserLogin,
     },
     insights::{RepositoryContributorInsights, UserCommitRepositoryInsights},
+    onboarding::{
+        CURRENT_ONBOARDING_VERSION, OnboardingProgress, OnboardingRecord, OnboardingStatus,
+    },
     ports::{
         BookmarkRepository, BookmarkService, CategoryRepository, DiscoveryRepository,
         DiscoveryService, ExplorationRepository, ExplorationService, GitHubAuthConfig,
         GitHubClientPort, GitHubImportRepository, GitHubSyncService, IdentityRepository,
-        IdentityService, InsightRepository, InsightService, SyncStateRepository,
+        IdentityService, InsightRepository, InsightService, OnboardingService, SyncStateRepository,
     },
     shared::{AppError, AppResult, GITHUB_CORE_REST_MINIMUM_RESERVE, ensure},
 };
@@ -49,6 +52,7 @@ pub struct AppServices {
     pub exploration: Arc<dyn ExplorationService>,
     pub discovery: Arc<dyn DiscoveryService>,
     pub insights: Arc<dyn InsightService>,
+    pub onboarding: Arc<dyn OnboardingService>,
 }
 
 #[derive(Clone)]
@@ -100,14 +104,14 @@ impl AppServices {
         let bookmarks = Arc::new(DefaultBookmarkService {
             import_repo: import_repo.clone(),
             category_repo,
-            bookmark_repo,
+            bookmark_repo: bookmark_repo.clone(),
         });
         let exploration = Arc::new(DefaultExplorationService { exploration_repo });
         let discovery = Arc::new(DefaultDiscoveryService {
             identity_repo: identity_repo.clone(),
             import_repo: import_repo.clone(),
-            sync_state_repo,
-            discovery_repo,
+            sync_state_repo: sync_state_repo.clone(),
+            discovery_repo: discovery_repo.clone(),
             github: github.clone(),
             refreshes,
             rate_budgets: rate_budgets.clone(),
@@ -121,6 +125,11 @@ impl AppServices {
             rate_budgets,
             cold_refreshes: InsightColdRefreshCoordinator::default(),
         });
+        let onboarding = Arc::new(DefaultOnboardingService {
+            sync_state_repo,
+            bookmark_repo,
+            discovery_repo,
+        });
 
         Self {
             identity,
@@ -129,6 +138,7 @@ impl AppServices {
             exploration,
             discovery,
             insights,
+            onboarding,
         }
     }
 }
@@ -794,6 +804,143 @@ impl ExplorationService for DefaultExplorationService {
         self.exploration_repo
             .list_exploration_snapshots(user_id)
             .await
+    }
+}
+
+pub struct DefaultOnboardingService {
+    sync_state_repo: Arc<dyn SyncStateRepository>,
+    bookmark_repo: Arc<dyn BookmarkRepository>,
+    discovery_repo: Arc<dyn DiscoveryRepository>,
+}
+
+impl DefaultOnboardingService {
+    async fn current_record(&self, user_id: &str) -> AppResult<Option<OnboardingRecord>> {
+        Ok(self
+            .sync_state_repo
+            .onboarding_record(user_id)
+            .await?
+            .filter(|record| record.version == CURRENT_ONBOARDING_VERSION))
+    }
+
+    async fn progress_for_record(
+        &self,
+        user_id: &str,
+        record: OnboardingRecord,
+    ) -> AppResult<OnboardingProgress> {
+        let (activity, bookmarks, warmup) = tokio::try_join!(
+            self.discovery_repo
+                .exploration_activity(user_id, MAX_RECENT_PEOPLE),
+            self.bookmark_repo.list_bookmarks(user_id),
+            self.sync_state_repo.discovery_warmup(user_id),
+        )?;
+
+        let (opened_trailhead, followed_connection, saved_repository) =
+            if record.status == OnboardingStatus::Completed {
+                (true, true, true)
+            } else if let Some(started_at) = record.started_at {
+                let recent_visits = activity
+                    .recent_people
+                    .iter()
+                    .filter(|person| person.last_viewed_at >= started_at)
+                    .collect::<Vec<_>>();
+                (
+                    !recent_visits.is_empty(),
+                    recent_visits.iter().any(|person| person.trail.len() >= 2),
+                    bookmarks.iter().any(|bookmark| {
+                        bookmark.created_at >= started_at
+                            && matches!(bookmark.target, BookmarkTarget::GitHubRepository { .. })
+                    }),
+                )
+            } else {
+                (false, false, false)
+            };
+
+        Ok(OnboardingProgress {
+            version: record.version,
+            status: record.status,
+            started_at: record.started_at,
+            completed_at: record.completed_at,
+            dismissed_at: record.dismissed_at,
+            opened_trailhead,
+            followed_connection,
+            saved_repository,
+            mapping_started: warmup.is_some(),
+        })
+    }
+}
+
+#[async_trait]
+impl OnboardingService for DefaultOnboardingService {
+    async fn progress(&self, user_id: &str) -> AppResult<OnboardingProgress> {
+        let Some(record) = self.current_record(user_id).await? else {
+            return Ok(OnboardingProgress::not_started());
+        };
+        self.progress_for_record(user_id, record).await
+    }
+
+    async fn begin(&self, user_id: &str) -> AppResult<OnboardingProgress> {
+        if let Some(record) = self.current_record(user_id).await? {
+            return self.progress_for_record(user_id, record).await;
+        }
+        let record = OnboardingRecord::in_progress(Utc::now());
+        self.sync_state_repo
+            .save_onboarding_record(user_id, record.clone())
+            .await?;
+        self.progress_for_record(user_id, record).await
+    }
+
+    async fn dismiss(&self, user_id: &str) -> AppResult<OnboardingProgress> {
+        let now = Utc::now();
+        let mut record = self
+            .current_record(user_id)
+            .await?
+            .unwrap_or_else(|| OnboardingRecord::in_progress(now));
+        if record.status != OnboardingStatus::Completed {
+            record.status = OnboardingStatus::Dismissed;
+            record.started_at.get_or_insert(now);
+            record.completed_at = None;
+            record.dismissed_at = Some(now);
+            self.sync_state_repo
+                .save_onboarding_record(user_id, record.clone())
+                .await?;
+        }
+        self.progress_for_record(user_id, record).await
+    }
+
+    async fn restart(&self, user_id: &str) -> AppResult<OnboardingProgress> {
+        let record = OnboardingRecord::in_progress(Utc::now());
+        self.sync_state_repo
+            .save_onboarding_record(user_id, record.clone())
+            .await?;
+        self.progress_for_record(user_id, record).await
+    }
+
+    async fn complete(&self, user_id: &str) -> AppResult<OnboardingProgress> {
+        let Some(mut record) = self.current_record(user_id).await? else {
+            return Err(AppError::Validation(
+                "onboarding must be started before it can be completed".to_string(),
+            ));
+        };
+        if record.status == OnboardingStatus::Completed {
+            return self.progress_for_record(user_id, record).await;
+        }
+        ensure(
+            record.status == OnboardingStatus::InProgress,
+            "onboarding must be active before it can be completed",
+        )?;
+        let progress = self.progress_for_record(user_id, record.clone()).await?;
+        ensure(
+            progress.required_steps_complete(),
+            "open a trailhead, follow a connection, and save a repository before completing onboarding",
+        )?;
+        let now = Utc::now();
+        record.status = OnboardingStatus::Completed;
+        record.completed_at = Some(now);
+        record.dismissed_at = None;
+        self.sync_state_repo
+            .save_onboarding_record(user_id, record.clone())
+            .await?;
+        self.progress_for_record(user_id, record).await
     }
 }
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -21,6 +21,7 @@ use crate::{
         USER_COMMIT_ACTIVITY_SOURCE, USER_COMMIT_ACTIVITY_WINDOW_DAYS, UserCommitRepository,
         UserCommitRepositoryInsights,
     },
+    onboarding::{OnboardingProgress, OnboardingStatus},
     shared::{AppError, Shared},
 };
 
@@ -101,6 +102,22 @@ impl QueryRoot {
             .map_err(graphql_error)
     }
 
+    #[graphql(complexity = 6)]
+    async fn onboarding_progress(
+        &self,
+        context: &Context<'_>,
+    ) -> GraphQlResult<OnboardingProgressObject> {
+        let user_id = request_user_id(context)?;
+        let state = context.data::<Shared<AppState>>()?;
+        state
+            .services
+            .onboarding
+            .progress(user_id)
+            .await
+            .map(OnboardingProgressObject::from)
+            .map_err(graphql_error)
+    }
+
     #[graphql(complexity = 12)]
     async fn repository_insights(
         &self,
@@ -175,6 +192,70 @@ impl MutationRoot {
             .start_warmup(user_id)
             .await
             .map(DiscoveryWarmupObject::from)
+            .map_err(graphql_error)
+    }
+
+    #[graphql(complexity = 6)]
+    async fn begin_onboarding(
+        &self,
+        context: &Context<'_>,
+    ) -> GraphQlResult<OnboardingProgressObject> {
+        let user_id = request_user_id(context)?;
+        let state = context.data::<Shared<AppState>>()?;
+        state
+            .services
+            .onboarding
+            .begin(user_id)
+            .await
+            .map(OnboardingProgressObject::from)
+            .map_err(graphql_error)
+    }
+
+    #[graphql(complexity = 6)]
+    async fn dismiss_onboarding(
+        &self,
+        context: &Context<'_>,
+    ) -> GraphQlResult<OnboardingProgressObject> {
+        let user_id = request_user_id(context)?;
+        let state = context.data::<Shared<AppState>>()?;
+        state
+            .services
+            .onboarding
+            .dismiss(user_id)
+            .await
+            .map(OnboardingProgressObject::from)
+            .map_err(graphql_error)
+    }
+
+    #[graphql(complexity = 6)]
+    async fn restart_onboarding(
+        &self,
+        context: &Context<'_>,
+    ) -> GraphQlResult<OnboardingProgressObject> {
+        let user_id = request_user_id(context)?;
+        let state = context.data::<Shared<AppState>>()?;
+        state
+            .services
+            .onboarding
+            .restart(user_id)
+            .await
+            .map(OnboardingProgressObject::from)
+            .map_err(graphql_error)
+    }
+
+    #[graphql(complexity = 6)]
+    async fn complete_onboarding(
+        &self,
+        context: &Context<'_>,
+    ) -> GraphQlResult<OnboardingProgressObject> {
+        let user_id = request_user_id(context)?;
+        let state = context.data::<Shared<AppState>>()?;
+        state
+            .services
+            .onboarding
+            .complete(user_id)
+            .await
+            .map(OnboardingProgressObject::from)
             .map_err(graphql_error)
     }
 
@@ -398,6 +479,54 @@ impl From<DiscoveryWarmupJob> for DiscoveryWarmupObject {
             updated_at: value.updated_at.to_rfc3339(),
             completed_at: value.completed_at.map(|timestamp| timestamp.to_rfc3339()),
             last_error: value.last_error,
+        }
+    }
+}
+
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub enum OnboardingStatusObject {
+    NotStarted,
+    InProgress,
+    Completed,
+    Dismissed,
+}
+
+impl From<OnboardingStatus> for OnboardingStatusObject {
+    fn from(value: OnboardingStatus) -> Self {
+        match value {
+            OnboardingStatus::NotStarted => Self::NotStarted,
+            OnboardingStatus::InProgress => Self::InProgress,
+            OnboardingStatus::Completed => Self::Completed,
+            OnboardingStatus::Dismissed => Self::Dismissed,
+        }
+    }
+}
+
+#[derive(SimpleObject)]
+pub struct OnboardingProgressObject {
+    pub version: i32,
+    pub status: OnboardingStatusObject,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub dismissed_at: Option<String>,
+    pub opened_trailhead: bool,
+    pub followed_connection: bool,
+    pub saved_repository: bool,
+    pub mapping_started: bool,
+}
+
+impl From<OnboardingProgress> for OnboardingProgressObject {
+    fn from(value: OnboardingProgress) -> Self {
+        Self {
+            version: value.version,
+            status: value.status.into(),
+            started_at: value.started_at.map(|timestamp| timestamp.to_rfc3339()),
+            completed_at: value.completed_at.map(|timestamp| timestamp.to_rfc3339()),
+            dismissed_at: value.dismissed_at.map(|timestamp| timestamp.to_rfc3339()),
+            opened_trailhead: value.opened_trailhead,
+            followed_connection: value.followed_connection,
+            saved_repository: value.saved_repository,
+            mapping_started: value.mapping_started,
         }
     }
 }
@@ -932,6 +1061,12 @@ mod tests {
         assert!(sdl.contains("explorationActivity(limit: Int!): ExplorationActivityObject!"));
         assert!(sdl.contains("recordPersonVisit("));
         assert!(sdl.contains("setRecentPersonVisible("));
+        assert!(sdl.contains("onboardingProgress: OnboardingProgressObject!"));
+        assert!(sdl.contains("beginOnboarding: OnboardingProgressObject!"));
+        assert!(sdl.contains("dismissOnboarding: OnboardingProgressObject!"));
+        assert!(sdl.contains("restartOnboarding: OnboardingProgressObject!"));
+        assert!(sdl.contains("completeOnboarding: OnboardingProgressObject!"));
+        assert!(!sdl.contains("onboardingProgress(userId:"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod graphql;
 pub mod http;
 pub mod identity;
 pub mod insights;
+pub mod onboarding;
 pub mod ports;
 pub mod schema;
 pub mod shared;
@@ -329,6 +330,148 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[tokio::test]
+    async fn onboarding_tracks_real_private_actions_and_replay_uses_a_fresh_window() {
+        let repositories = LocalRepositorySet::in_memory();
+        repositories
+            .imports
+            .import_github_graph(
+                "onboarding-user",
+                GraphImport {
+                    viewer: Some(test_user(1, "alice")),
+                    following: vec![test_user(2, "bob")],
+                    starred_repositories: vec![test_repository(
+                        10,
+                        "acme/trail-map",
+                        "Rust",
+                        80,
+                        6,
+                    )],
+                    coverage: GraphImportCoverage::default(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("seed onboarding graph");
+        let services = AppServices::new(
+            AppServiceRepositories {
+                identity: repositories.identity,
+                imports: repositories.imports,
+                sync_state: repositories.sync_state,
+                categories: repositories.categories,
+                bookmarks: repositories.bookmarks,
+                exploration: repositories.exploration,
+                discovery: repositories.discovery,
+                insights: repositories.insights,
+            },
+            Arc::new(StubGitHubClient::default()),
+            GitHubAuthConfig {
+                client_id: secrecy::SecretString::from("stub-client"),
+                client_secret: None,
+                redirect_uri: None,
+                scopes: vec!["read:user".to_string()],
+            },
+        );
+
+        let initial = services
+            .onboarding
+            .progress("onboarding-user")
+            .await
+            .expect("initial onboarding");
+        assert_eq!(
+            initial.status,
+            crate::onboarding::OnboardingStatus::NotStarted
+        );
+        let started = services
+            .onboarding
+            .begin("onboarding-user")
+            .await
+            .expect("begin onboarding");
+        assert_eq!(
+            started.status,
+            crate::onboarding::OnboardingStatus::InProgress
+        );
+        assert!(
+            services
+                .onboarding
+                .complete("onboarding-user")
+                .await
+                .is_err()
+        );
+
+        services
+            .discovery
+            .record_person_visit(
+                "onboarding-user",
+                "alice",
+                vec!["alice".to_string()],
+                crate::discovery::ExplorationDirection::Following,
+            )
+            .await
+            .expect("record trailhead");
+        services
+            .discovery
+            .record_person_visit(
+                "onboarding-user",
+                "bob",
+                vec!["alice".to_string(), "bob".to_string()],
+                crate::discovery::ExplorationDirection::Following,
+            )
+            .await
+            .expect("record connection");
+        services
+            .bookmarks
+            .add_bookmark(
+                "onboarding-user",
+                BookmarkTarget::GitHubRepository {
+                    full_name: "acme/trail-map".to_string(),
+                },
+                Vec::new(),
+                None,
+            )
+            .await
+            .expect("save onboarding repository");
+
+        let completed = services
+            .onboarding
+            .complete("onboarding-user")
+            .await
+            .expect("complete onboarding");
+        assert_eq!(
+            completed.status,
+            crate::onboarding::OnboardingStatus::Completed
+        );
+        assert!(completed.required_steps_complete());
+        assert_eq!(
+            services
+                .onboarding
+                .progress("another-user")
+                .await
+                .expect("isolated onboarding")
+                .status,
+            crate::onboarding::OnboardingStatus::NotStarted
+        );
+
+        let replayed = services
+            .onboarding
+            .restart("onboarding-user")
+            .await
+            .expect("restart onboarding");
+        assert!(!replayed.opened_trailhead);
+        assert!(!replayed.followed_connection);
+        assert!(!replayed.saved_repository);
+        let dismissed = services
+            .onboarding
+            .dismiss("onboarding-user")
+            .await
+            .expect("dismiss replay");
+        assert_eq!(
+            dismissed.status,
+            crate::onboarding::OnboardingStatus::Dismissed
+        );
+        assert!(dismissed.dismissed_at.is_some());
     }
 
     #[tokio::test]

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -1,0 +1,78 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const CURRENT_ONBOARDING_VERSION: i32 = 1;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OnboardingStatus {
+    NotStarted,
+    InProgress,
+    Completed,
+    Dismissed,
+}
+
+impl OnboardingStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NotStarted => "not_started",
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+            Self::Dismissed => "dismissed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OnboardingRecord {
+    pub version: i32,
+    pub status: OnboardingStatus,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub dismissed_at: Option<DateTime<Utc>>,
+}
+
+impl OnboardingRecord {
+    pub fn in_progress(now: DateTime<Utc>) -> Self {
+        Self {
+            version: CURRENT_ONBOARDING_VERSION,
+            status: OnboardingStatus::InProgress,
+            started_at: Some(now),
+            completed_at: None,
+            dismissed_at: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OnboardingProgress {
+    pub version: i32,
+    pub status: OnboardingStatus,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub dismissed_at: Option<DateTime<Utc>>,
+    pub opened_trailhead: bool,
+    pub followed_connection: bool,
+    pub saved_repository: bool,
+    pub mapping_started: bool,
+}
+
+impl OnboardingProgress {
+    pub fn not_started() -> Self {
+        Self {
+            version: CURRENT_ONBOARDING_VERSION,
+            status: OnboardingStatus::NotStarted,
+            started_at: None,
+            completed_at: None,
+            dismissed_at: None,
+            opened_trailhead: false,
+            followed_connection: false,
+            saved_repository: false,
+            mapping_started: false,
+        }
+    }
+
+    pub fn required_steps_complete(&self) -> bool {
+        self.opened_trailhead && self.followed_connection && self.saved_repository
+    }
+}

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -14,6 +14,7 @@ use crate::{
         RepositoryContributorInsights, RepositoryContributorsSnapshot,
         UserCommitRepositoriesSnapshot, UserCommitRepositoryInsights,
     },
+    onboarding::{OnboardingProgress, OnboardingRecord},
     shared::{AppError, AppResult},
 };
 
@@ -167,6 +168,12 @@ pub trait SyncStateRepository: Send + Sync {
         warmup: DiscoveryWarmupJob,
         lease: &RefreshLease,
     ) -> AppResult<bool>;
+    async fn onboarding_record(&self, user_id: &str) -> AppResult<Option<OnboardingRecord>>;
+    async fn save_onboarding_record(
+        &self,
+        user_id: &str,
+        record: OnboardingRecord,
+    ) -> AppResult<()>;
 }
 
 #[async_trait]
@@ -406,4 +413,13 @@ pub trait InsightService: Send + Sync {
         login: &str,
         limit: usize,
     ) -> AppResult<UserCommitRepositoryInsights>;
+}
+
+#[async_trait]
+pub trait OnboardingService: Send + Sync {
+    async fn progress(&self, user_id: &str) -> AppResult<OnboardingProgress>;
+    async fn begin(&self, user_id: &str) -> AppResult<OnboardingProgress>;
+    async fn dismiss(&self, user_id: &str) -> AppResult<OnboardingProgress>;
+    async fn restart(&self, user_id: &str) -> AppResult<OnboardingProgress>;
+    async fn complete(&self, user_id: &str) -> AppResult<OnboardingProgress>;
 }


### PR DESCRIPTION
## Summary
- add versioned, private onboarding persistence and authenticated GraphQL lifecycle operations
- guide users through opening a trailhead, following a connection, and saving a ranked repository
- keep discovery mapping explicit and optional, with replay, skip, accessibility, and failure recovery
- add API, React, Rust, Playwright/axe, CI, and documentation coverage

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --locked`
- `pnpm --filter @gitexplore/api-client test`
- `pnpm --filter @gitexplore/web test`
- `pnpm --filter @gitexplore/web test:e2e`
- `pnpm --filter @gitexplore/web check`
- `pnpm check`
- `pnpm production:check`
- `pnpm --filter @gitexplore/web build`