### PR TITLE
Remove image outline from GitExplore wordmark

### DIFF
--- a/apps/web/e2e/onboarding.spec.ts
+++ b/apps/web/e2e/onboarding.spec.ts
@@ -146,6 +146,7 @@ test('connected user reaches a private first save through the onboarding trail',
   const wordmark = page.locator('.brand-wordmark').first();
   await expect(wordmark).toBeVisible();
   await expect.poll(() => wordmark.evaluate((image) => (image as HTMLImageElement).naturalWidth)).toBeGreaterThan(0);
+  await expect.poll(() => wordmark.evaluate((image) => getComputedStyle(image).outlineStyle)).toBe('none');
   await expect(page.getByRole('link', { name: 'GitExplore Explore' }).first().locator('svg')).toHaveCount(0);
   await expect(page.getByRole('heading', { name: 'Your first GitExplore trail' })).toBeVisible();
   expect((await new AxeBuilder({ page }).include('.onboarding-card').analyze()).violations).toEqual([]);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -100,6 +100,7 @@ a {
   max-width: 100%;
   object-fit: contain;
   object-position: left center;
+  outline: none;
   user-select: none;
 }
 


### PR DESCRIPTION
## Summary
- opt the transparent GitExplore wordmark out of Strawn's global editorial image outline
- add a Playwright computed-style regression so the rectangular frame cannot return

## Verification
- pnpm --filter @gitexplore/web test
- pnpm --filter @gitexplore/web check
- pnpm --filter @gitexplore/web test:e2e -- --grep 'atlas onboarding'
- mobile visual inspection