### PR TITLE
Keep GitHub sign-in available

### DIFF
--- a/apps/web/e2e/login.spec.ts
+++ b/apps/web/e2e/login.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+test('GitHub sign-in is available with the quiet outlined treatment', async ({ page }, testInfo) => {
+  await page.route('**/auth/status', async (route) => {
+    await route.fulfill({
+      json: { authenticated: false, app_user_id: null, connected: false, account: null },
+    });
+  });
+
+  await page.goto('/login');
+
+  const connect = page.getByRole('link', { name: 'Continue with GitHub' });
+  await expect(connect).toBeVisible();
+  await expect(connect).toHaveAttribute('href', /\/auth\/oauth\/start\?redirect_to=/);
+  await expect(connect).not.toHaveAttribute('aria-disabled', 'true');
+
+  const treatment = await connect.evaluate((element) => {
+    const styles = getComputedStyle(element);
+    return {
+      backgroundColor: styles.backgroundColor,
+      borderStyle: styles.borderStyle,
+      borderColor: styles.borderColor,
+      color: styles.color,
+    };
+  });
+
+  expect(treatment.backgroundColor).toBe('rgb(255, 255, 255)');
+  expect(treatment.borderStyle).toBe('solid');
+  expect(treatment.borderColor).not.toBe(treatment.backgroundColor);
+  expect(treatment.color).not.toBe(treatment.borderColor);
+
+  await testInfo.attach('login-connect', {
+    body: await page.locator('.login-connect').screenshot({ animations: 'disabled' }),
+    contentType: 'image/png',
+  });
+  if (process.env.GITEXPLORE_VISUAL_OUTPUT_DIR) {
+    await page.locator('.login-connect').screenshot({
+      animations: 'disabled',
+      path: `${process.env.GITEXPLORE_VISUAL_OUTPUT_DIR}/login-connect.png`,
+    });
+  }
+});

--- a/apps/web/src/pages/LoginPage.test.tsx
+++ b/apps/web/src/pages/LoginPage.test.tsx
@@ -22,7 +22,7 @@ describe('LoginPage', () => {
     authState.refresh.mockClear();
   });
 
-  it('does not activate OAuth while session status is pending', () => {
+  it('keeps OAuth available while session status is pending', () => {
     render(<ThemeProvider><MemoryRouter><LoginPage /></MemoryRouter></ThemeProvider>);
     expect(screen.getByRole('link', { name: 'GitExplore home' }).querySelector('img')).toHaveAttribute(
       'src',
@@ -30,9 +30,10 @@ describe('LoginPage', () => {
     );
     const link = screen.getByText(/continue with github/i).closest('a');
     expect(link).not.toBeNull();
-    expect(link).not.toHaveAttribute('href');
-    expect(link).toHaveAttribute('aria-disabled', 'true');
-    expect(link).toHaveAttribute('tabindex', '-1');
+    expect(link).toHaveAttribute('href', '/auth/oauth/start');
+    expect(link).not.toHaveAttribute('aria-disabled');
+    expect(link).not.toHaveAttribute('tabindex');
+    expect(link).toHaveClass('github-connect-link');
   });
 
   it('shows a backend error instead of treating it as signed out', () => {

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -67,11 +67,8 @@ export function LoginPage() {
 
           <div className="login-action">
             <a
-              className={`primary-link${loading ? ' pending' : ''}`}
-              href={loading ? undefined : api.startBrowserOAuth(returnUrl)}
-              aria-disabled={loading || undefined}
-              tabIndex={loading ? -1 : undefined}
-              onClick={loading ? (event) => event.preventDefault() : undefined}
+              className="primary-link github-connect-link"
+              href={api.startBrowserOAuth(returnUrl)}
             >
               <span><GitHubIcon aria-hidden="true" size={18} /> Continue with GitHub</span>
               <ArrowRightIcon aria-hidden="true" size={17} />

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -582,9 +582,23 @@ a {
   gap: var(--space-2);
 }
 
-.primary-link.pending {
-  cursor: wait;
-  opacity: var(--effect-disabled-opacity);
+.github-connect-link {
+  border: var(--border-weight-subtle) solid var(--primary);
+  background: var(--surface);
+  color: var(--foreground);
+  transition: background-color var(--motion-duration-fast) var(--motion-ease-standard);
+}
+
+.github-connect-link:hover {
+  background: var(--muted);
+}
+
+.github-connect-link:active {
+  background: var(--surface-inset);
+}
+
+.github-connect-link:focus-visible {
+  outline-color: var(--foreground);
 }
 
 .secondary-link {


### PR DESCRIPTION
## Summary
- keep the OAuth link actionable during the initial session-status request
- restyle the GitHub connection action as a white control with a single violet border and dark content
- use neutral hover/active states and a dark visible keyboard focus ring
- add unit and Playwright coverage for the real OAuth target and visual treatment

## Verification
- cargo test
- pnpm --filter @gitexplore/api-client test
- pnpm --filter @gitexplore/web test
- pnpm --filter @gitexplore/web check
- pnpm --filter @gitexplore/web test:e2e
- pnpm check
- Playwright visual inspection